### PR TITLE
Feat: Add reusable FeatureCard component

### DIFF
--- a/frontend/components/general/FeatureCard.jsx
+++ b/frontend/components/general/FeatureCard.jsx
@@ -1,0 +1,15 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+const FeatureCard = ({ icon, title, description }) => (
+  <Card className="backdrop-blur-lg bg-white/10 border-white/20 text-white hover:bg-white/20 transition-colors">
+    <CardContent className="p-6">
+      <div className="flex flex-col items-center text-center">
+        {icon}
+        <h3 className="text-xl font-bold mt-4 mb-2">{title}</h3>
+        <p className="text-gray-300">{description}</p>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+export default FeatureCard;


### PR DESCRIPTION
1. Created a reusable FeatureCard component inside the frontend/components/general folder.

2. Used ShadCN-UI’s Card and CardContent components for consistency.

3. Implemented the following props:

- icon: Displays an icon.

- title: Displays the feature title.

- description: Displays a short description.

4. Applied a frosted glass effect using backdrop-blur-lg bg-white/10 for a modern, semi-transparent look.

5. Ensured the component is responsive and matches the existing design patterns.

6. Used Tailwind CSS classes for styling and theme consistency.