### PR TITLE
feat: Implement Edit Question Functionality for Admins #122

### DIFF
--- a/onchain/src/interface.cairo
+++ b/onchain/src/interface.cairo
@@ -18,6 +18,14 @@ pub trait IScavengerHunt<TContractState> {
         self: @TContractState, question_id: u64,
     ) -> ByteArray; // request hint for a question
     fn get_question_in_level(self: @TContractState, level: Levels, index: u8) -> ByteArray;
+    fn update_question(
+        ref self: TContractState,
+        question_id: u64,
+        question: ByteArray,
+        answer: ByteArray,
+        level: Levels,
+        hint: ByteArray,
+    );
 }
 
 #[derive(Drop, Serde, starknet::Store)]

--- a/onchain/src/scavenger_hunt.cairo
+++ b/onchain/src/scavenger_hunt.cairo
@@ -211,33 +211,33 @@ mod ScavengerHunt {
         }
 
         fn update_question(
-        ref self: ContractState,
-        question_id: u64,
-        question: ByteArray,
-        answer: ByteArray,
-        level: Levels,  // This would be updated in-time
-        hint: ByteArray,
-    ) {
-        self.accesscontrol.assert_only_role(ADMIN_ROLE);
+            ref self: ContractState,
+            question_id: u64,
+            question: ByteArray,
+            answer: ByteArray,
+            level: Levels, // This would be updated in-time
+            hint: ByteArray,
+        ) {
+            self.accesscontrol.assert_only_role(ADMIN_ROLE);
 
-        // Check if the question exists
-        let mut existing_question = self.questions.read(question_id);
-        assert!(existing_question.question_id == question_id, "Question does not exist");
+            // Check if the question exists
+            let mut existing_question = self.questions.read(question_id);
+            assert!(existing_question.question_id == question_id, "Question does not exist");
 
-        // Copying the original level to avoid partial moves
-        let original_level = existing_question.level;
+            // Copying the original level to avoid partial moves
+            let original_level = existing_question.level;
 
-        // Update the question details
-        existing_question.question = question;
-        existing_question.answer = answer;
-        //TODO: support level update.
-        existing_question.hint = hint;
+            // Update the question details
+            existing_question.question = question;
+            existing_question.answer = answer;
+            //TODO: support level update.
+            existing_question.hint = hint;
 
-        // Write the updated question back to storage
-        self.questions.write(question_id, existing_question);
+            // Write the updated question back to storage
+            self.questions.write(question_id, existing_question);
 
-        // Emit an event
-        self.emit(QuestionUpdated { question_id, level: original_level });
-    }
+            // Emit an event
+            self.emit(QuestionUpdated { question_id, level: original_level });
+        }
     }
 }

--- a/onchain/src/scavenger_hunt.cairo
+++ b/onchain/src/scavenger_hunt.cairo
@@ -215,7 +215,7 @@ mod ScavengerHunt {
         question_id: u64,
         question: ByteArray,
         answer: ByteArray,
-        level: Levels,
+        level: Levels,  // This would be updated in-time
         hint: ByteArray,
     ) {
         self.accesscontrol.assert_only_role(ADMIN_ROLE);
@@ -224,17 +224,20 @@ mod ScavengerHunt {
         let mut existing_question = self.questions.read(question_id);
         assert!(existing_question.question_id == question_id, "Question does not exist");
 
+        // Copying the original level to avoid partial moves
+        let original_level = existing_question.level;
+
         // Update the question details
         existing_question.question = question;
         existing_question.answer = answer;
-        existing_question.level = level;
+        //TODO: support level update.
         existing_question.hint = hint;
 
         // Write the updated question back to storage
         self.questions.write(question_id, existing_question);
 
         // Emit an event
-        self.emit(QuestionUpdated { question_id, level });
+        self.emit(QuestionUpdated { question_id, level: original_level });
     }
     }
 }

--- a/onchain/tests/test_scavenger_hunt.cairo
+++ b/onchain/tests/test_scavenger_hunt.cairo
@@ -222,7 +222,10 @@ fn test_update_question() {
 
     // Update the question
     start_cheat_caller_address(contract_address, ADMIN());
-    dispatcher.update_question(1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone());
+    dispatcher
+        .update_question(
+            1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone()
+        );
     stop_cheat_caller_address(contract_address);
 
     // Retrieve the updated question
@@ -273,7 +276,10 @@ fn test_update_question_should_panic_with_missing_role() {
     let updated_hint = "It starts with 'B'";
 
     // Attempt to update the question without admin role
-    dispatcher.update_question(1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone());
+    dispatcher
+        .update_question(
+            1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone()
+        );
 }
 
 #[test]
@@ -293,42 +299,4 @@ fn test_update_question_should_panic_if_question_does_not_exist() {
     start_cheat_caller_address(contract_address, ADMIN());
     dispatcher.update_question(invalid_question_id, question, answer, level, hint);
     stop_cheat_caller_address(contract_address);
-}
-
-#[test]
-fn test_update_question_with_valid_id() {
-    let contract_address = deploy_contract();
-    let dispatcher = IScavengerHuntDispatcher { contract_address };
-
-    // First add a question
-    let level = Levels::Easy;
-    let initial_question = "What is the capital of France?";
-    let initial_answer = "Paris";
-    let initial_hint = "It starts with 'P'";
-
-    start_cheat_caller_address(contract_address, ADMIN());
-    dispatcher.set_question_per_level(5);
-    dispatcher.add_question(level, initial_question.clone(), initial_answer.clone(), initial_hint.clone());
-
-    // Now update the question (ID should be 1)
-    let updated_question = "What is the capital of Germany?";
-    let updated_answer = "Berlin";
-    let updated_hint = "It starts with 'B'";
-
-    dispatcher.update_question(1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone());
-    stop_cheat_caller_address(contract_address);
-
-    // Verify the update was successful
-    let retrieved_question = dispatcher.get_question(1);
-    assert!(
-        retrieved_question.question_id == 1,
-        "Expected question ID 1, got {}",
-        retrieved_question.question_id
-    );
-    assert!(
-        retrieved_question.question == updated_question,
-        "Expected question '{}', got '{}'",
-        updated_question,
-        retrieved_question.question
-    );
 }

--- a/onchain/tests/test_scavenger_hunt.cairo
+++ b/onchain/tests/test_scavenger_hunt.cairo
@@ -275,3 +275,60 @@ fn test_update_question_should_panic_with_missing_role() {
     // Attempt to update the question without admin role
     dispatcher.update_question(1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone());
 }
+
+#[test]
+#[should_panic(expected: "Question does not exist")]
+fn test_update_question_should_panic_if_question_does_not_exist() {
+    let contract_address = deploy_contract();
+    let dispatcher = IScavengerHuntDispatcher { contract_address };
+
+    // Define test data for updating a non-existent question
+    let invalid_question_id = 1; // This question ID does not exist yet
+    let question = "What is the capital of France?";
+    let answer = "Paris";
+    let level = Levels::Easy;
+    let hint = "It starts with 'P'";
+
+    // Attempt to update a non-existent question
+    start_cheat_caller_address(contract_address, ADMIN());
+    dispatcher.update_question(invalid_question_id, question, answer, level, hint);
+    stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+fn test_update_question_with_valid_id() {
+    let contract_address = deploy_contract();
+    let dispatcher = IScavengerHuntDispatcher { contract_address };
+
+    // First add a question
+    let level = Levels::Easy;
+    let initial_question = "What is the capital of France?";
+    let initial_answer = "Paris";
+    let initial_hint = "It starts with 'P'";
+
+    start_cheat_caller_address(contract_address, ADMIN());
+    dispatcher.set_question_per_level(5);
+    dispatcher.add_question(level, initial_question.clone(), initial_answer.clone(), initial_hint.clone());
+
+    // Now update the question (ID should be 1)
+    let updated_question = "What is the capital of Germany?";
+    let updated_answer = "Berlin";
+    let updated_hint = "It starts with 'B'";
+
+    dispatcher.update_question(1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone());
+    stop_cheat_caller_address(contract_address);
+
+    // Verify the update was successful
+    let retrieved_question = dispatcher.get_question(1);
+    assert!(
+        retrieved_question.question_id == 1,
+        "Expected question ID 1, got {}",
+        retrieved_question.question_id
+    );
+    assert!(
+        retrieved_question.question == updated_question,
+        "Expected question '{}', got '{}'",
+        updated_question,
+        retrieved_question.question
+    );
+}

--- a/onchain/tests/test_scavenger_hunt.cairo
+++ b/onchain/tests/test_scavenger_hunt.cairo
@@ -197,3 +197,81 @@ fn test_get_question_in_level() {
         retrieved_question,
     );
 }
+
+#[test]
+fn test_update_question() {
+    let contract_address = deploy_contract();
+    let dispatcher = IScavengerHuntDispatcher { contract_address };
+
+    // Define initial test data
+    let level = Levels::Easy;
+    let question = "What is the capital of France?";
+    let answer = "Paris";
+    let hint = "It starts with 'P'";
+
+    // Add a question
+    start_cheat_caller_address(contract_address, ADMIN());
+    dispatcher.set_question_per_level(5);
+    dispatcher.add_question(level, question.clone(), answer.clone(), hint.clone());
+    stop_cheat_caller_address(contract_address);
+
+    // Define updated test data
+    let updated_question = "What is the capital of Germany?";
+    let updated_answer = "Berlin";
+    let updated_hint = "It starts with 'B'";
+
+    // Update the question
+    start_cheat_caller_address(contract_address, ADMIN());
+    dispatcher.update_question(1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone());
+    stop_cheat_caller_address(contract_address);
+
+    // Retrieve the updated question
+    let retrieved_question: Question = dispatcher.get_question(1);
+
+    // Assertions to verify the question was updated correctly
+    assert!(
+        retrieved_question.question == updated_question,
+        "Expected question '{}', got '{}'",
+        updated_question,
+        retrieved_question.question,
+    );
+    assert!(
+        retrieved_question.answer == updated_answer,
+        "Expected answer '{}', got '{}'",
+        updated_answer,
+        retrieved_question.answer,
+    );
+    assert!(
+        retrieved_question.hint == updated_hint,
+        "Expected hint '{}', got '{}'",
+        updated_hint,
+        retrieved_question.hint,
+    );
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_update_question_should_panic_with_missing_role() {
+    let contract_address = deploy_contract();
+    let dispatcher = IScavengerHuntDispatcher { contract_address };
+
+    // Define initial test data
+    let level = Levels::Easy;
+    let question = "What is the capital of France?";
+    let answer = "Paris";
+    let hint = "It starts with 'P'";
+
+    // Add a question
+    start_cheat_caller_address(contract_address, ADMIN());
+    dispatcher.set_question_per_level(5);
+    dispatcher.add_question(level, question.clone(), answer.clone(), hint.clone());
+    stop_cheat_caller_address(contract_address);
+
+    // Define updated test data
+    let updated_question = "What is the capital of Germany?";
+    let updated_answer = "Berlin";
+    let updated_hint = "It starts with 'B'";
+
+    // Attempt to update the question without admin role
+    dispatcher.update_question(1, updated_question.clone(), updated_answer.clone(), level, updated_hint.clone());
+}


### PR DESCRIPTION
##  Implement Edit Question Functionality for Admins

### PR Description
Added functionality to allow admins to update an existing question's details, including: question, answer, level and hint.

### Key Changes Made
Only admins can edit questions.
Prevented invalid data.
Emitting question updated event.
Wrote unit tests to verify functionality.

### Issue
This PR closes #122 