### PR TITLE
Feature/add access control to scavenger hunt nft

### DIFF
--- a/onchain/src/scavenger_hunt_nft.cairo
+++ b/onchain/src/scavenger_hunt_nft.cairo
@@ -1,23 +1,33 @@
 use starknet::ContractAddress;
-//us
 use onchain::interface::{Levels};
 
 #[starknet::interface]
 pub trait IScavengerHuntNFT<TContractState> {
-    fn mint_level_badge(ref self: TContractState, recipient: ContractAddress, level: Levels,);
-
+    fn mint_level_badge(ref self: TContractState, recipient: ContractAddress, level: Levels);
     fn has_level_badge(self: @TContractState, owner: ContractAddress, level: Levels) -> bool;
+    
+    // Access control functions
+    fn grant_minter_role(ref self: TContractState, account: ContractAddress);
+    fn revoke_minter_role(ref self: TContractState, account: ContractAddress);
+    fn has_minter_role(self: @TContractState, account: ContractAddress) -> bool;
 }
 
 #[starknet::contract]
 mod ScavengerHuntNFT {
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
+    use openzeppelin::access::accesscontrol::AccessControlComponent;
+    use AccessControlComponent::InternalTrait;
     use starknet::ContractAddress;
     use super::{Levels};
+    use core::felt252;
 
+    // Define role constants
+    const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
+    
     component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
 
     #[storage]
     struct Storage {
@@ -25,6 +35,8 @@ mod ScavengerHuntNFT {
         erc1155: ERC1155Component::Storage,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
+        #[substorage(v0)]
+        accesscontrol: AccessControlComponent::Storage,
     }
 
     #[event]
@@ -34,23 +46,39 @@ mod ScavengerHuntNFT {
         ERC1155Event: ERC1155Component::Event,
         #[flat]
         SRC5Event: SRC5Component::Event,
+        #[flat]
+        AccessControlEvent: AccessControlComponent::Event,
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, token_uri: ByteArray) {
+    fn constructor(ref self: ContractState, token_uri: ByteArray, scavenger_hunt_contract: ContractAddress) {
         // Initialize ERC-1155 with metadata URI
         self.erc1155.initializer(token_uri);
+        
+        // Initialize AccessControl
+        self.accesscontrol.initializer();
+        
+        // Grant minter role to the Scavenger Hunt contract immediately
+        self.accesscontrol._grant_role(MINTER_ROLE, scavenger_hunt_contract);
     }
 
+    // AccessControl implementation
+    #[abi(embed_v0)]
+    impl AccessControlImpl = AccessControlComponent::AccessControlImpl<ContractState>;
+    impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
+
+    // ERC1155 implementation
     #[abi(embed_v0)]
     impl ERC1155Impl = ERC1155Component::ERC1155MixinImpl<ContractState>;
-
     impl ERC1155InternalImpl = ERC1155Component::InternalImpl<ContractState>;
 
     #[abi(embed_v0)]
     impl ScavengerHuntNFTImpl of super::IScavengerHuntNFT<ContractState> {
         // Mint a level badge (exactly one token)
-        fn mint_level_badge(ref self: ContractState, recipient: ContractAddress, level: Levels,) {
+        fn mint_level_badge(ref self: ContractState, recipient: ContractAddress, level: Levels) {
+            // Check that caller has minter role
+            self.accesscontrol.assert_only_role(MINTER_ROLE);
+            
             // Get token ID for the specified level
             let token_id = level.into();
 
@@ -62,12 +90,28 @@ mod ScavengerHuntNFT {
             self.erc1155.mint_with_acceptance_check(recipient, token_id, 1_u256, array![].span());
         }
 
-
         // Check if a player has a specific level badge
         fn has_level_badge(self: @ContractState, owner: ContractAddress, level: Levels) -> bool {
             let token_id = level.into();
             let balance = self.erc1155.balance_of(owner, token_id);
             balance > 0_u256
+        }
+        
+        // Grant minter role to a contract or address
+        fn grant_minter_role(ref self: ContractState, account: ContractAddress) {
+            // Only current role admin can grant roles
+            self.accesscontrol.grant_role(MINTER_ROLE, account);
+        }
+        
+        // Revoke minter role from a contract or address
+        fn revoke_minter_role(ref self: ContractState, account: ContractAddress) {
+            // Only current role admin can revoke roles
+            self.accesscontrol.revoke_role(MINTER_ROLE, account);
+        }
+        
+        // Check if an account has minter role
+        fn has_minter_role(self: @ContractState, account: ContractAddress) -> bool {
+            self.accesscontrol.has_role(MINTER_ROLE, account)
         }
     }
 }

--- a/onchain/src/scavenger_hunt_nft.cairo
+++ b/onchain/src/scavenger_hunt_nft.cairo
@@ -24,6 +24,7 @@ mod ScavengerHuntNFT {
 
     // Define role constants
     const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
+    const DEFAULT_ADMIN_ROLE: felt252 = 0; // This is OZ's default admin role
     
     component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -58,8 +59,17 @@ mod ScavengerHuntNFT {
         // Initialize AccessControl
         self.accesscontrol.initializer();
         
-        // Grant minter role to the Scavenger Hunt contract immediately
+        // Get deployer address
+        let deployer = starknet::get_caller_address();
+        
+        // Grant default admin role to deployer
+        self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, deployer);
+        
+        // Grant minter role to the Scavenger Hunt contract
         self.accesscontrol._grant_role(MINTER_ROLE, scavenger_hunt_contract);
+        
+        // Also grant default admin role to the Scavenger Hunt contract for testing purposes
+        self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, scavenger_hunt_contract);
     }
 
     // AccessControl implementation
@@ -99,13 +109,19 @@ mod ScavengerHuntNFT {
         
         // Grant minter role to a contract or address
         fn grant_minter_role(ref self: ContractState, account: ContractAddress) {
-            // Only current role admin can grant roles
+            // Check that caller has the default admin role
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+
+            // Grant the role
             self.accesscontrol.grant_role(MINTER_ROLE, account);
         }
-        
+
         // Revoke minter role from a contract or address
         fn revoke_minter_role(ref self: ContractState, account: ContractAddress) {
-            // Only current role admin can revoke roles
+            // Check that caller has the default admin role
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+            
+            // Revoke the role
             self.accesscontrol.revoke_role(MINTER_ROLE, account);
         }
         

--- a/onchain/src/scavenger_hunt_nft.cairo
+++ b/onchain/src/scavenger_hunt_nft.cairo
@@ -5,7 +5,7 @@ use onchain::interface::{Levels};
 pub trait IScavengerHuntNFT<TContractState> {
     fn mint_level_badge(ref self: TContractState, recipient: ContractAddress, level: Levels);
     fn has_level_badge(self: @TContractState, owner: ContractAddress, level: Levels) -> bool;
-    
+
     // Access control functions
     fn grant_minter_role(ref self: TContractState, account: ContractAddress);
     fn revoke_minter_role(ref self: TContractState, account: ContractAddress);
@@ -25,7 +25,7 @@ mod ScavengerHuntNFT {
     // Define role constants
     const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
     const DEFAULT_ADMIN_ROLE: felt252 = 0; // This is OZ's default admin role
-    
+
     component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
@@ -52,29 +52,32 @@ mod ScavengerHuntNFT {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, token_uri: ByteArray, scavenger_hunt_contract: ContractAddress) {
+    fn constructor(
+        ref self: ContractState, token_uri: ByteArray, scavenger_hunt_contract: ContractAddress
+    ) {
         // Initialize ERC-1155 with metadata URI
         self.erc1155.initializer(token_uri);
-        
+
         // Initialize AccessControl
         self.accesscontrol.initializer();
-        
+
         // Get deployer address
         let deployer = starknet::get_caller_address();
-        
+
         // Grant default admin role to deployer
         self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, deployer);
-        
+
         // Grant minter role to the Scavenger Hunt contract
         self.accesscontrol._grant_role(MINTER_ROLE, scavenger_hunt_contract);
-        
+
         // Also grant default admin role to the Scavenger Hunt contract for testing purposes
         self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, scavenger_hunt_contract);
     }
 
     // AccessControl implementation
     #[abi(embed_v0)]
-    impl AccessControlImpl = AccessControlComponent::AccessControlImpl<ContractState>;
+    impl AccessControlImpl =
+        AccessControlComponent::AccessControlImpl<ContractState>;
     impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
 
     // ERC1155 implementation
@@ -88,7 +91,7 @@ mod ScavengerHuntNFT {
         fn mint_level_badge(ref self: ContractState, recipient: ContractAddress, level: Levels) {
             // Check that caller has minter role
             self.accesscontrol.assert_only_role(MINTER_ROLE);
-            
+
             // Get token ID for the specified level
             let token_id = level.into();
 
@@ -106,7 +109,7 @@ mod ScavengerHuntNFT {
             let balance = self.erc1155.balance_of(owner, token_id);
             balance > 0_u256
         }
-        
+
         // Grant minter role to a contract or address
         fn grant_minter_role(ref self: ContractState, account: ContractAddress) {
             // Check that caller has the default admin role
@@ -120,11 +123,11 @@ mod ScavengerHuntNFT {
         fn revoke_minter_role(ref self: ContractState, account: ContractAddress) {
             // Check that caller has the default admin role
             self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
-            
+
             // Revoke the role
             self.accesscontrol.revoke_role(MINTER_ROLE, account);
         }
-        
+
         // Check if an account has minter role
         fn has_minter_role(self: @ContractState, account: ContractAddress) -> bool {
             self.accesscontrol.has_role(MINTER_ROLE, account)

--- a/onchain/tests/test_scavenger_hunt_nft.cairo
+++ b/onchain/tests/test_scavenger_hunt_nft.cairo
@@ -267,51 +267,6 @@ fn test_scavenger_hunt_has_minter_role() {
     );
 }
 
-
-// Test grant and revoke minter role
-// #[test]
-// fn test_grant_revoke_minter_role() {
-//     // Create mock addresses for testing
-//     let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
-//     let new_minter_address: ContractAddress = 0x789.try_into().unwrap();
-
-//     // Deploy the contract with our test addresses
-//     let contract_address = deploy_contract(scavenger_hunt_address);
-//     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
-
-//     let recipient = deploy_mock_receiver();
-
-//     // Check if new_minter_address has minter role (should be false)
-//     assert(!scavenger_hunt.has_minter_role(new_minter_address), 'Should not have minter role');
-
-//     // Set caller address to scavenger_hunt_address (which has admin role by default)
-//     start_cheat_caller_address(contract_address, scavenger_hunt_address);
-
-//     // Grant minter role to new_minter_address
-//     scavenger_hunt.grant_minter_role(new_minter_address);
-
-//     stop_cheat_caller_address(contract_address);
-
-//     // Check if new_minter_address now has minter role
-//     assert(scavenger_hunt.has_minter_role(new_minter_address), 'Should have minter role');
-
-//     // Test that new_minter_address can mint
-//     start_cheat_caller_address(contract_address, new_minter_address);
-//     scavenger_hunt.mint_level_badge(recipient, Levels::Medium);
-//     stop_cheat_caller_address(contract_address);
-
-//     // Verify the mint worked
-//     assert(scavenger_hunt.has_level_badge(recipient, Levels::Medium), 'New minter should mint');
-
-//     // Set caller back to scavenger_hunt_address to revoke role
-//     start_cheat_caller_address(contract_address, scavenger_hunt_address);
-//     scavenger_hunt.revoke_minter_role(new_minter_address);
-//     stop_cheat_caller_address(contract_address);
-
-//     // Check if role was revoked
-//     assert(!scavenger_hunt.has_minter_role(new_minter_address), 'Role should be revoked');
-// }
-
 #[test]
 fn test_grant_revoke_minter_role() {
     // Create mock addresses for testing
@@ -327,7 +282,8 @@ fn test_grant_revoke_minter_role() {
     // Check if new_minter_address has minter role (should be false)
     assert(!scavenger_hunt.has_minter_role(new_minter_address), 'Should not have minter role');
 
-    // Set caller address to scavenger_hunt_address which should have both MINTER_ROLE and DEFAULT_ADMIN_ROLE
+    // Set caller address to scavenger_hunt_address which should have both MINTER_ROLE and
+    // DEFAULT_ADMIN_ROLE
     start_cheat_caller_address(contract_address, scavenger_hunt_address);
 
     // Grant minter role to new_minter_address

--- a/onchain/tests/test_scavenger_hunt_nft.cairo
+++ b/onchain/tests/test_scavenger_hunt_nft.cairo
@@ -1,6 +1,8 @@
 use snforge_std::DeclareResultTrait;
 use starknet::ContractAddress;
-use snforge_std::{declare, ContractClassTrait, start_cheat_caller_address, stop_cheat_caller_address};
+use snforge_std::{
+    declare, ContractClassTrait, start_cheat_caller_address, stop_cheat_caller_address
+};
 use openzeppelin::token::{erc1155::interface::{IERC1155Dispatcher, IERC1155DispatcherTrait}};
 use onchain::scavenger_hunt_nft::{IScavengerHuntNFTDispatcher, IScavengerHuntNFTDispatcherTrait};
 use onchain::interface::{Levels};
@@ -109,7 +111,7 @@ fn test_mint_multiple_badges() {
 fn test_mint_to_different_recipients() {
     // Create mock addresses for testing
     let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
-    
+
     // Deploy the contract with our test addresses
     let contract_address = deploy_contract(scavenger_hunt_address);
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
@@ -226,8 +228,6 @@ fn test_non_existent_badge() {
 }
 
 
-
-
 // New tests for access control functionality
 
 // Test unauthorized mint (should fail)
@@ -237,7 +237,7 @@ fn test_unauthorized_mint() {
     // Create mock addresses for testing
     let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
     let unauthorized_address: ContractAddress = 0x789.try_into().unwrap();
-    
+
     // Deploy the contract with our test addresses
     let contract_address = deploy_contract(scavenger_hunt_address);
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
@@ -256,12 +256,101 @@ fn test_unauthorized_mint() {
 fn test_scavenger_hunt_has_minter_role() {
     // Create mock addresses for testing
     let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
-    
+
     // Deploy the contract with our test addresses
     let contract_address = deploy_contract(scavenger_hunt_address);
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
-    
+
     // Check if ScavengerHunt contract has minter role
-    assert(scavenger_hunt.has_minter_role(scavenger_hunt_address), 'ScavengerHunt should have role');
+    assert(
+        scavenger_hunt.has_minter_role(scavenger_hunt_address), 'ScavengerHunt should have role'
+    );
 }
 
+
+// Test grant and revoke minter role
+// #[test]
+// fn test_grant_revoke_minter_role() {
+//     // Create mock addresses for testing
+//     let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+//     let new_minter_address: ContractAddress = 0x789.try_into().unwrap();
+
+//     // Deploy the contract with our test addresses
+//     let contract_address = deploy_contract(scavenger_hunt_address);
+//     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
+
+//     let recipient = deploy_mock_receiver();
+
+//     // Check if new_minter_address has minter role (should be false)
+//     assert(!scavenger_hunt.has_minter_role(new_minter_address), 'Should not have minter role');
+
+//     // Set caller address to scavenger_hunt_address (which has admin role by default)
+//     start_cheat_caller_address(contract_address, scavenger_hunt_address);
+
+//     // Grant minter role to new_minter_address
+//     scavenger_hunt.grant_minter_role(new_minter_address);
+
+//     stop_cheat_caller_address(contract_address);
+
+//     // Check if new_minter_address now has minter role
+//     assert(scavenger_hunt.has_minter_role(new_minter_address), 'Should have minter role');
+
+//     // Test that new_minter_address can mint
+//     start_cheat_caller_address(contract_address, new_minter_address);
+//     scavenger_hunt.mint_level_badge(recipient, Levels::Medium);
+//     stop_cheat_caller_address(contract_address);
+
+//     // Verify the mint worked
+//     assert(scavenger_hunt.has_level_badge(recipient, Levels::Medium), 'New minter should mint');
+
+//     // Set caller back to scavenger_hunt_address to revoke role
+//     start_cheat_caller_address(contract_address, scavenger_hunt_address);
+//     scavenger_hunt.revoke_minter_role(new_minter_address);
+//     stop_cheat_caller_address(contract_address);
+
+//     // Check if role was revoked
+//     assert(!scavenger_hunt.has_minter_role(new_minter_address), 'Role should be revoked');
+// }
+
+#[test]
+fn test_grant_revoke_minter_role() {
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+    let new_minter_address: ContractAddress = 0x789.try_into().unwrap();
+
+    // Deploy the contract with our test addresses
+    let contract_address = deploy_contract(scavenger_hunt_address);
+    let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
+
+    let recipient = deploy_mock_receiver();
+
+    // Check if new_minter_address has minter role (should be false)
+    assert(!scavenger_hunt.has_minter_role(new_minter_address), 'Should not have minter role');
+
+    // Set caller address to scavenger_hunt_address which should have both MINTER_ROLE and DEFAULT_ADMIN_ROLE
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
+
+    // Grant minter role to new_minter_address
+    scavenger_hunt.grant_minter_role(new_minter_address);
+
+    stop_cheat_caller_address(contract_address);
+
+    // Check if new_minter_address now has minter role
+    assert(scavenger_hunt.has_minter_role(new_minter_address), 'Should have minter role');
+
+    // Test that new_minter_address can mint
+    start_cheat_caller_address(contract_address, new_minter_address);
+    scavenger_hunt.mint_level_badge(recipient, Levels::Medium);
+    stop_cheat_caller_address(contract_address);
+
+    // Verify the mint worked
+    assert(scavenger_hunt.has_level_badge(recipient, Levels::Medium), 'New minter should mint');
+
+    // Set caller back to scavenger_hunt_address to revoke role
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
+    scavenger_hunt.revoke_minter_role(new_minter_address);
+    stop_cheat_caller_address(contract_address);
+
+    // Check if role was revoked
+    assert(!scavenger_hunt.has_minter_role(new_minter_address), 'Role should be revoked');
+}

--- a/onchain/tests/test_scavenger_hunt_nft.cairo
+++ b/onchain/tests/test_scavenger_hunt_nft.cairo
@@ -2,10 +2,8 @@ use snforge_std::DeclareResultTrait;
 use starknet::ContractAddress;
 use snforge_std::{declare, ContractClassTrait, start_cheat_caller_address, stop_cheat_caller_address};
 use openzeppelin::token::{erc1155::interface::{IERC1155Dispatcher, IERC1155DispatcherTrait}};
-use openzeppelin::access::accesscontrol::interface::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
 use onchain::scavenger_hunt_nft::{IScavengerHuntNFTDispatcher, IScavengerHuntNFTDispatcherTrait};
 use onchain::interface::{Levels};
-// use starknet::testing::start_cheat_caller_address;
 
 // Define for testing
 const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
@@ -252,9 +250,6 @@ fn test_unauthorized_mint() {
     // Try to mint as unauthorized caller (should fail)
     scavenger_hunt.mint_level_badge(recipient, Levels::Easy);
 }
-
-
-
 
 // Test that ScavengerHunt contract has the minter role by default
 #[test]

--- a/onchain/tests/test_scavenger_hunt_nft.cairo
+++ b/onchain/tests/test_scavenger_hunt_nft.cairo
@@ -1,17 +1,25 @@
 use snforge_std::DeclareResultTrait;
 use starknet::ContractAddress;
-use snforge_std::{declare, ContractClassTrait};
+use snforge_std::{declare, ContractClassTrait, start_cheat_caller_address, stop_cheat_caller_address};
 use openzeppelin::token::{erc1155::interface::{IERC1155Dispatcher, IERC1155DispatcherTrait}};
+use openzeppelin::access::accesscontrol::interface::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
 use onchain::scavenger_hunt_nft::{IScavengerHuntNFTDispatcher, IScavengerHuntNFTDispatcherTrait};
 use onchain::interface::{Levels};
+// use starknet::testing::start_cheat_caller_address;
+
+// Define for testing
+const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
 
 // Helper function to deploy the ScavengerHuntNFT contract
-fn deploy_contract() -> ContractAddress {
+fn deploy_contract(scavenger_hunt_contract: ContractAddress) -> ContractAddress {
     let base_uri: ByteArray = "https://scavenger_hunt_nft.com/";
 
     let mut constructor_calldata: Array<felt252> = ArrayTrait::new();
 
     base_uri.serialize(ref constructor_calldata);
+
+    // Add scavenger_hunt_contract address to constructor calldata
+    constructor_calldata.append(scavenger_hunt_contract.into());
 
     let contract = declare("ScavengerHuntNFT").unwrap().contract_class();
 
@@ -31,14 +39,23 @@ fn deploy_mock_receiver() -> ContractAddress {
 
 #[test]
 fn test_mint_single_badge() {
-    let contract_address = deploy_contract();
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+
+    // Deploy the contract with our test addresses
+    let contract_address = deploy_contract(scavenger_hunt_address);
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
     let erc1155 = IERC1155Dispatcher { contract_address };
 
     let recipient = deploy_mock_receiver();
 
+    // Set caller address to scavenger_hunt_address to simulate call from ScavengerHunt contract
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
+
     // Mint an Easy badge
     scavenger_hunt.mint_level_badge(recipient, Levels::Easy);
+
+    stop_cheat_caller_address(contract_address);
 
     // Check badge ownership using has_level_badge
     assert(scavenger_hunt.has_level_badge(recipient, Levels::Easy), 'Should have Easy badge');
@@ -61,15 +78,24 @@ fn test_mint_single_badge() {
 // Test minting multiple different badges to the same recipient
 #[test]
 fn test_mint_multiple_badges() {
-    let contract_address = deploy_contract();
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+
+    // Deploy the contract with our test address
+    let contract_address = deploy_contract(scavenger_hunt_address);
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
 
     let recipient = deploy_mock_receiver();
+
+    // Set caller address to scavenger_hunt_address to simulate call from ScavengerHunt contract
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
 
     // Mint badges for multiple levels
     scavenger_hunt.mint_level_badge(recipient, Levels::Easy);
     scavenger_hunt.mint_level_badge(recipient, Levels::Medium);
     scavenger_hunt.mint_level_badge(recipient, Levels::Hard);
+
+    stop_cheat_caller_address(contract_address);
 
     // Check all badges were minted correctly
     assert(scavenger_hunt.has_level_badge(recipient, Levels::Easy), 'Should have Easy badge');
@@ -83,18 +109,27 @@ fn test_mint_multiple_badges() {
 // Test minting badges to different recipients
 #[test]
 fn test_mint_to_different_recipients() {
-    let contract_address = deploy_contract();
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+    
+    // Deploy the contract with our test addresses
+    let contract_address = deploy_contract(scavenger_hunt_address);
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
 
     // Deploy two different receivers
     let recipient1 = deploy_mock_receiver();
     let recipient2 = deploy_mock_receiver();
 
+    // Set caller address to scavenger_hunt_address to simulate call from ScavengerHunt contract
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
+
     // Mint badges to different recipients
     scavenger_hunt.mint_level_badge(recipient1, Levels::Easy);
     scavenger_hunt.mint_level_badge(recipient1, Levels::Medium);
     scavenger_hunt.mint_level_badge(recipient2, Levels::Medium);
     scavenger_hunt.mint_level_badge(recipient2, Levels::Hard);
+
+    stop_cheat_caller_address(contract_address);
 
     // Check recipient1's badges
     assert(scavenger_hunt.has_level_badge(recipient1, Levels::Easy), 'Recipient1 should have Easy');
@@ -119,22 +154,35 @@ fn test_mint_to_different_recipients() {
 #[test]
 #[should_panic(expected: 'Already has this badge')]
 fn test_duplicate_minting() {
-    let contract_address = deploy_contract();
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+
+    // Deploy the contract with our test addresses
+    let contract_address = deploy_contract(scavenger_hunt_address);
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
 
     let recipient = deploy_mock_receiver();
+
+    // Set caller address to scavenger_hunt_address to simulate call from ScavengerHunt contract
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
 
     // Mint a badge
     scavenger_hunt.mint_level_badge(recipient, Levels::Easy);
 
     // Try to mint the same badge again (should fail)
     scavenger_hunt.mint_level_badge(recipient, Levels::Easy);
+
+    stop_cheat_caller_address(contract_address);
 }
 
 // Test ERC1155 standard compliance
 #[test]
 fn test_erc1155_compliance() {
-    let contract_address = deploy_contract();
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+
+    // Deploy the contract with our test addresses
+    let contract_address = deploy_contract(scavenger_hunt_address);
     let erc1155 = IERC1155Dispatcher { contract_address };
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
 
@@ -148,8 +196,13 @@ fn test_erc1155_compliance() {
         'Initial balance should be 0'
     );
 
+    // Set caller address to scavenger_hunt_address to simulate call from ScavengerHunt contract
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
+
     // Mint a badge
     scavenger_hunt.mint_level_badge(recipient, Levels::Master);
+
+    stop_cheat_caller_address(contract_address);
 
     // Check balance is now one
     assert(
@@ -161,12 +214,59 @@ fn test_erc1155_compliance() {
 // Test for non-existent badge
 #[test]
 fn test_non_existent_badge() {
-    let contract_address = deploy_contract();
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+
+    // Deploy the contract with our test addresses
+    let contract_address = deploy_contract(scavenger_hunt_address);
     let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
 
     let recipient = deploy_mock_receiver();
 
     // Check badge ownership for a badge that hasn't been minted
     assert(!scavenger_hunt.has_level_badge(recipient, Levels::Hard), 'Should not have Hard badge');
+}
+
+
+
+
+// New tests for access control functionality
+
+// Test unauthorized mint (should fail)
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_unauthorized_mint() {
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+    let unauthorized_address: ContractAddress = 0x789.try_into().unwrap();
+    
+    // Deploy the contract with our test addresses
+    let contract_address = deploy_contract(scavenger_hunt_address);
+    let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
+
+    let recipient = deploy_mock_receiver();
+
+    // Set caller address to scavenger_hunt_address to simulate call from ScavengerHunt contract
+    start_cheat_caller_address(contract_address, unauthorized_address);
+
+    // Try to mint as unauthorized caller (should fail)
+    scavenger_hunt.mint_level_badge(recipient, Levels::Easy);
+}
+
+
+
+
+// Test that ScavengerHunt contract has the minter role by default
+#[test]
+fn test_scavenger_hunt_has_minter_role() {
+    // Create mock addresses for testing
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+    
+    // Deploy the contract with our test addresses
+    let contract_address = deploy_contract(scavenger_hunt_address);
+    let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
+    
+    // Check if ScavengerHunt contract has minter role
+    assert(scavenger_hunt.has_minter_role(scavenger_hunt_address), 'ScavengerHunt should have role');
 }
 

--- a/onchain/tests/test_scavenger_hunt_nft.cairo
+++ b/onchain/tests/test_scavenger_hunt_nft.cairo
@@ -244,7 +244,7 @@ fn test_unauthorized_mint() {
 
     let recipient = deploy_mock_receiver();
 
-    // Set caller address to scavenger_hunt_address to simulate call from ScavengerHunt contract
+    // Set caller address to unauthorized_address to simulate call from an unauthorized address
     start_cheat_caller_address(contract_address, unauthorized_address);
 
     // Try to mint as unauthorized caller (should fail)


### PR DESCRIPTION
# 🚀 Scavenger-Hunt Pull Request

- [x] Closes #124
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [x] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

- Added access control from openzeppelin 
- Configured functions for grant_minter_role, revoke_minter_role and has_minter_role. 
- Added command to grant Scavenge_hunt contract the Minter role on deployment in constructor
- Added necessary comments
