### PR TITLE
[Feat]: Add NFT Contract Configuration

### DIFF
--- a/onchain/src/contracts/scavenger_hunt.cairo
+++ b/onchain/src/contracts/scavenger_hunt.cairo
@@ -40,6 +40,7 @@ pub mod ScavengerHunt {
         player_level_progress: Map<
             (ContractAddress, felt252), LevelProgress,
         >, // (user, level) -> LevelProgress
+        nft_contract_address: ContractAddress,
         #[substorage(v0)]
         accesscontrol: AccessControlComponent::Storage,
         #[substorage(v0)]
@@ -58,6 +59,7 @@ pub mod ScavengerHunt {
         SRC5Event: SRC5Component::Event,
         LevelCompleted: LevelCompleted,
         AnswerSubmitted: AnswerSubmitted,
+        NFTContractUpdated: NFTContractUpdated,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -92,6 +94,12 @@ pub mod ScavengerHunt {
         pub question_id: u64,
         pub level: Levels,
         pub is_correct: bool,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct NFTContractUpdated {
+        pub old_address: ContractAddress,
+        pub new_address: ContractAddress,
     }
 
     #[constructor]
@@ -315,6 +323,17 @@ pub mod ScavengerHunt {
             let player_level = player_progress.current_level;
 
             player_level
+        }
+
+        fn set_nft_contract_address(ref self: ContractState, new_address: ContractAddress) {
+            self.accesscontrol.assert_only_role(ADMIN_ROLE);
+            let old_address = self.nft_contract_address.read();
+            self.nft_contract_address.write(new_address);
+            self.emit(NFTContractUpdated { old_address, new_address });
+        }
+
+        fn get_nft_contract_address(self: @ContractState) -> ContractAddress {
+            self.nft_contract_address.read()
         }
     }
 }

--- a/onchain/src/contracts/scavenger_hunt_nft.cairo
+++ b/onchain/src/contracts/scavenger_hunt_nft.cairo
@@ -32,7 +32,6 @@ pub mod ScavengerHuntNFT {
 
     #[storage]
     struct Storage {
-        
         #[substorage(v0)]
         erc1155: ERC1155Component::Storage,
         #[substorage(v0)]

--- a/onchain/src/contracts/scavenger_hunt_nft.cairo
+++ b/onchain/src/contracts/scavenger_hunt_nft.cairo
@@ -32,6 +32,7 @@ pub mod ScavengerHuntNFT {
 
     #[storage]
     struct Storage {
+        
         #[substorage(v0)]
         erc1155: ERC1155Component::Storage,
         #[substorage(v0)]

--- a/onchain/src/interface.cairo
+++ b/onchain/src/interface.cairo
@@ -28,6 +28,8 @@ pub trait IScavengerHunt<TContractState> {
     );
     fn next_level(self: @TContractState, level: Levels) -> Levels;
     fn get_player_level(self: @TContractState, player: ContractAddress) -> Levels;
+    fn set_nft_contract_address(ref self: TContractState, new_address: ContractAddress);
+    fn get_nft_contract_address(self: @TContractState) -> ContractAddress;
 }
 
 #[derive(Drop, Debug, Serde, starknet::Store)]

--- a/onchain/tests/test_scavenger_hunt.cairo
+++ b/onchain/tests/test_scavenger_hunt.cairo
@@ -477,11 +477,11 @@ fn test_set_nft_contract_address() {
     let contract_address = deploy_contract();
     let dispatcher = IScavengerHuntDispatcher { contract_address };
     let new_nft_address = contract_address_const::<'NEW_NFT'>();
-    
+
     start_cheat_caller_address(contract_address, ADMIN());
     dispatcher.set_nft_contract_address(new_nft_address);
     stop_cheat_caller_address(contract_address);
-    
+
     let stored_address = dispatcher.get_nft_contract_address();
     assert!(stored_address == new_nft_address, "wrong_nft_address");
 }
@@ -492,6 +492,6 @@ fn test_set_nft_contract_address_should_panic_with_missing_role() {
     let contract_address = deploy_contract();
     let dispatcher = IScavengerHuntDispatcher { contract_address };
     let new_nft_address = contract_address_const::<'NEW_NFT'>();
-    
+
     dispatcher.set_nft_contract_address(new_nft_address);
 }

--- a/onchain/tests/test_scavenger_hunt.cairo
+++ b/onchain/tests/test_scavenger_hunt.cairo
@@ -472,3 +472,26 @@ fn test_multiple_level_progressions() {
     stop_cheat_caller_address(contract_address);
 }
 
+#[test]
+fn test_set_nft_contract_address() {
+    let contract_address = deploy_contract();
+    let dispatcher = IScavengerHuntDispatcher { contract_address };
+    let new_nft_address = contract_address_const::<'NEW_NFT'>();
+    
+    start_cheat_caller_address(contract_address, ADMIN());
+    dispatcher.set_nft_contract_address(new_nft_address);
+    stop_cheat_caller_address(contract_address);
+    
+    let stored_address = dispatcher.get_nft_contract_address();
+    assert!(stored_address == new_nft_address, "wrong_nft_address");
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_set_nft_contract_address_should_panic_with_missing_role() {
+    let contract_address = deploy_contract();
+    let dispatcher = IScavengerHuntDispatcher { contract_address };
+    let new_nft_address = contract_address_const::<'NEW_NFT'>();
+    
+    dispatcher.set_nft_contract_address(new_nft_address);
+}


### PR DESCRIPTION
## Close #348
feat: Add NFT Contract Configuration #348

## Description
The ScavengerHunt contract needs functionality to set and get the NFT contract address that will be used for minting level completion rewards. This will allow the admin to configure which NFT contract should be used for minting operations and enable querying this information.

## Acceptance criteria

- [x] Add storage variable for the NFT contract address.
- [x] Add admin function to set the NFT contract address.
- [x] Add public function to get the current NFT contract address.
- [x] Add events for NFT contract updates.
- [x] Add appropriate access control.
- [x] Add full test for this

## Screenshot 

![Screenshot from 2025-03-27 16-58-34](https://github.com/user-attachments/assets/187b7033-e387-4bd9-a323-433be264988e)

