### PR TITLE
implement this and opimize Implement Dynamic In-App Notifications Module

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -53,7 +53,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",
         "@types/multer": "^1.4.12",
-        "@types/node": "^20.17.52",
+        "@types/node": "^20.17.57",
         "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -2694,9 +2694,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.52.tgz",
-      "integrity": "sha512-2aj++KfxubvW/Lc0YyXE3OEW7Es8TWn1MsRzYgcOGyTNQxi0L8rxQUCZ7ZbyOBWZQD5I63PV9egZWMsapVaklg==",
+      "version": "20.17.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
+      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"

--- a/backend/package.json
+++ b/backend/package.json
@@ -65,7 +65,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.2",
     "@types/multer": "^1.4.12",
-    "@types/node": "^20.17.52",
+    "@types/node": "^20.17.57",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -48,6 +48,7 @@ import { PuzzleMatchingModule } from './puzzle-matching/puzzle-matching.module';
 import { UserEventsModule } from './user-events/user-events.module';
 import { DailyPuzzleModule } from './daily-puzzle/daily-puzzle.module';
 import { LocationModule } from './location/location.module';
+import { InAppNotificationsModule } from './in-app-notifications/in-app-notifications.module';
 
 
 @Module({
@@ -112,6 +113,7 @@ import { LocationModule } from './location/location.module';
     UserEventsModule,
     DailyPuzzleModule,
     LocationModule,
+    InAppNotificationsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/auth/guards/ws-jwt-auth.guard.ts
+++ b/backend/src/auth/guards/ws-jwt-auth.guard.ts
@@ -1,0 +1,35 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { WsException } from '@nestjs/websockets';
+import { Socket } from 'socket.io';
+
+@Injectable()
+export class WsJwtAuthGuard implements CanActivate {
+  constructor(private jwtService: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    try {
+      const client: Socket = context.switchToWs().getClient();
+      const token = this.extractTokenFromHeader(client);
+      
+      if (!token) {
+        throw new WsException('Unauthorized');
+      }
+
+      const payload = await this.jwtService.verifyAsync(token, {
+        secret: process.env.JWT_SECRET,
+      });
+
+      // Attach the user to the socket for later use
+      client.data.user = payload;
+      return true;
+    } catch {
+      throw new WsException('Unauthorized');
+    }
+  }
+
+  private extractTokenFromHeader(client: Socket): string | undefined {
+    const [type, token] = client.handshake.headers.authorization?.split(' ') ?? [];
+    return type === 'Bearer' ? token : undefined;
+  }
+} 

--- a/backend/src/in-app-notifications/dto/create-in-app-notification.dto.ts
+++ b/backend/src/in-app-notifications/dto/create-in-app-notification.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsOptional, IsEnum, IsUrl, IsNumber, Min, Max, IsArray } from 'class-validator';
+import { InAppNotificationType } from '../entities/in-app-notification.entity';
+
+export class CreateInAppNotificationDto {
+  @ApiProperty({ description: 'User ID to send notification to' })
+  @IsNotEmpty()
+  @IsNumber()
+  userId: number;
+
+  @ApiProperty({ description: 'Notification title' })
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiProperty({ description: 'Notification message', required: false })
+  @IsOptional()
+  @IsString()
+  message?: string;
+
+  @ApiProperty({ description: 'URL to navigate to when notification is clicked', required: false })
+  @IsOptional()
+  @IsUrl()
+  url?: string;
+
+  @ApiProperty({ description: 'Notification type', enum: InAppNotificationType, default: InAppNotificationType.GENERAL })
+  @IsOptional()
+  @IsEnum(InAppNotificationType)
+  type?: InAppNotificationType = InAppNotificationType.GENERAL;
+
+  @ApiProperty({ description: 'Additional metadata for the notification', required: false })
+  @IsOptional()
+  metadata?: Record<string, any>;
+
+  @ApiProperty({ description: 'Notification priority (0-10)', required: false, minimum: 0, maximum: 10 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(10)
+  priority?: number = 0;
+}
+
+export class MarkAsReadDto {
+  @ApiProperty({ description: 'Array of notification IDs to mark as read' })
+  @IsNotEmpty()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  notificationIds: number[];
+}
+
+export class ArchiveNotificationsDto {
+  @ApiProperty({ description: 'Array of notification IDs to archive' })
+  @IsNotEmpty()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  notificationIds: number[];
+}

--- a/backend/src/in-app-notifications/dto/update-in-app-notification.dto.ts
+++ b/backend/src/in-app-notifications/dto/update-in-app-notification.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateInAppNotificationDto } from './create-in-app-notification.dto';
+
+export class UpdateInAppNotificationDto extends PartialType(CreateInAppNotificationDto) {}

--- a/backend/src/in-app-notifications/entities/in-app-notification.entity.ts
+++ b/backend/src/in-app-notifications/entities/in-app-notification.entity.ts
@@ -1,0 +1,72 @@
+import { User } from "src/users/users.entity";
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, Index, JoinColumn } from "typeorm";
+
+
+export enum InAppNotificationType {
+  GENERAL = 'GENERAL',
+  ACHIEVEMENT = 'ACHIEVEMENT',
+  REWARD = 'REWARD',
+  SYSTEM = 'SYSTEM',
+  PROFILE_UPDATE = 'PROFILE_UPDATE',
+  WELCOME = 'WELCOME',
+  CHALLENGE = 'CHALLENGE',
+  NFT = 'NFT',
+  LEADERBOARD = 'LEADERBOARD',
+  FRIEND = 'FRIEND',
+  GAME = 'GAME'
+}
+
+@Entity('in_app_notifications')
+@Index(['userId', 'isRead'])
+@Index(['userId', 'createdAt'])
+export class InAppNotification {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  @Index()
+  userId: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  message?: string;
+
+  @Column({ nullable: true })
+  url?: string;
+
+  @Column({
+    type: 'enum',
+    enum: InAppNotificationType,
+    default: InAppNotificationType.GENERAL,
+  })
+  type: InAppNotificationType;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata?: Record<string, any>;
+
+  @Column({ default: false })
+  @Index()
+  isRead: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  readAt?: Date;
+
+  @Column({ default: false })
+  isArchived: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  archivedAt?: Date;
+
+  @Column({ type: 'int', default: 0 })
+  priority: number;
+
+  @CreateDateColumn()
+  @Index()
+  createdAt: Date;
+}

--- a/backend/src/in-app-notifications/enum/in-appnotification.enum.ts
+++ b/backend/src/in-app-notifications/enum/in-appnotification.enum.ts
@@ -1,0 +1,5 @@
+export enum InAppNotificationType {
+  GENERAL = 'GENERAL',
+  PROFILE_UPDATE = 'PROFILE_UPDATE', 
+  WELCOME = 'WELCOME',               
+}

--- a/backend/src/in-app-notifications/in-app-notifications-gateway.ts
+++ b/backend/src/in-app-notifications/in-app-notifications-gateway.ts
@@ -1,0 +1,31 @@
+import { WebSocketGateway, WebSocketServer } from "@nestjs/websockets";
+import { InAppNotification } from "./entities/in-app-notification.entity";
+import { Server } from "http";
+import { Socket } from 'socket.io';
+
+
+// in-app-notifications.gateway.ts
+@WebSocketGateway({ cors: true })
+export class InAppNotificationsGateway {
+  @WebSocketServer()
+  server: Server;
+
+  private clients = new Map<number, Socket>();
+
+  handleConnection(socket: Socket) {
+    const userId = Number(socket.handshake.query.userId);
+    this.clients.set(userId, socket);
+  }
+
+  handleDisconnect(socket: Socket) {
+    const userId = Number(socket.handshake.query.userId);
+    this.clients.delete(userId);
+  }
+
+  sendNotification(userId: number, notification: InAppNotification) {
+    const client = this.clients.get(userId);
+    if (client) {
+      client.emit('new-in-app-notification', notification);
+    }
+  }
+}

--- a/backend/src/in-app-notifications/in-app-notifications.controller.spec.ts
+++ b/backend/src/in-app-notifications/in-app-notifications.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InAppNotificationsController } from './in-app-notifications.controller';
+import { InAppNotificationsService } from './in-app-notifications.service';
+
+describe('InAppNotificationsController', () => {
+  let controller: InAppNotificationsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InAppNotificationsController],
+      providers: [InAppNotificationsService],
+    }).compile();
+
+    controller = module.get<InAppNotificationsController>(InAppNotificationsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/in-app-notifications/in-app-notifications.controller.ts
+++ b/backend/src/in-app-notifications/in-app-notifications.controller.ts
@@ -1,0 +1,94 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, UseGuards, ParseIntPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { InAppNotificationsService } from './in-app-notifications.service';
+import { CreateInAppNotificationDto } from './dto/create-in-app-notification.dto';
+import { InAppNotificationType } from './entities/in-app-notification.entity';
+import { WsJwtAuthGuard } from 'src/auth/guards/ws-jwt-auth.guard';
+
+@ApiTags('in-app-notifications')
+@Controller('in-app-notifications')
+@UseGuards(WsJwtAuthGuard)
+@ApiBearerAuth()
+export class InAppNotificationsController {
+  constructor(private readonly notificationsService: InAppNotificationsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get user notifications' })
+  @ApiQuery({ name: 'isRead', required: false, type: Boolean })
+  @ApiQuery({ name: 'isArchived', required: false, type: Boolean })
+  @ApiQuery({ name: 'type', required: false, enum: InAppNotificationType })
+  @ApiQuery({ name: 'startDate', required: false, type: Date })
+  @ApiQuery({ name: 'endDate', required: false, type: Date })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Returns user notifications' })
+  async getUserNotifications(
+    @Query('isRead') isRead?: boolean,
+    @Query('isArchived') isArchived?: boolean,
+    @Query('type') type?: InAppNotificationType,
+    @Query('startDate') startDate?: Date,
+    @Query('endDate') endDate?: Date,
+    @Query('limit') limit?: number,
+    @Query('offset') offset?: number,
+  ) {
+    return this.notificationsService.getUserNotifications(1, {
+      isRead,
+      isArchived,
+      type,
+      startDate,
+      endDate,
+      limit,
+      offset,
+    });
+  }
+
+  @Get('unread-count')
+  @ApiOperation({ summary: 'Get unread notifications count' })
+  @ApiResponse({ status: 200, description: 'Returns unread notifications count' })
+  async getUnreadCount() {
+    return this.notificationsService.getUnreadCount(1);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new notification' })
+  @ApiResponse({ status: 201, description: 'Notification created successfully' })
+  async create(@Body() createDto: CreateInAppNotificationDto) {
+    return this.notificationsService.create(createDto);
+  }
+
+  @Post('system')
+  @ApiOperation({ summary: 'Create a system-wide notification' })
+  @ApiResponse({ status: 201, description: 'System notification created successfully' })
+  async createSystemNotification(@Body() notification: Omit<CreateInAppNotificationDto, 'userId'>) {
+    return this.notificationsService.createSystemNotification(notification);
+  }
+
+  @Patch('read')
+  @ApiOperation({ summary: 'Mark notifications as read' })
+  @ApiResponse({ status: 200, description: 'Notifications marked as read' })
+  async markAsRead(@Body('notificationIds') notificationIds: number[]) {
+    return this.notificationsService.markAsRead(notificationIds);
+  }
+
+  @Patch('read-all')
+  @ApiOperation({ summary: 'Mark all notifications as read' })
+  @ApiResponse({ status: 200, description: 'All notifications marked as read' })
+  async markAllAsRead() {
+    return this.notificationsService.markAllAsRead(1);
+  }
+
+  @Patch('archive')
+  @ApiOperation({ summary: 'Archive notifications' })
+  @ApiResponse({ status: 200, description: 'Notifications archived successfully' })
+  async archiveNotifications(@Body('notificationIds') notificationIds: number[]) {
+    return this.notificationsService.archiveNotifications(notificationIds);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a notification' })
+  @ApiResponse({ status: 200, description: 'Notification deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Notification not found' })
+  async delete(@Param('id', ParseIntPipe) id: number) {
+    return this.notificationsService.delete(id);
+  }
+}

--- a/backend/src/in-app-notifications/in-app-notifications.gateway.ts
+++ b/backend/src/in-app-notifications/in-app-notifications.gateway.ts
@@ -1,0 +1,125 @@
+import { WebSocketGateway, WebSocketServer, OnGatewayConnection, OnGatewayDisconnect, SubscribeMessage } from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { UseGuards, Logger } from '@nestjs/common';
+import { WsJwtAuthGuard } from '../auth/guards/ws-jwt-auth.guard';
+import { InAppNotification } from './entities/in-app-notification.entity';
+
+@WebSocketGateway({
+  cors: {
+    origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+    credentials: true,
+  },
+  namespace: 'notifications',
+})
+export class InAppNotificationsGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server: Server;
+
+  private readonly logger = new Logger(InAppNotificationsGateway.name);
+  private readonly clients = new Map<number, Socket>();
+
+  async handleConnection(socket: Socket) {
+    try {
+      const userId = this.getUserIdFromSocket(socket);
+      if (!userId) {
+        this.logger.warn('Connection attempt without user ID');
+        socket.disconnect();
+        return;
+      }
+
+      this.clients.set(userId, socket);
+      this.logger.log(`Client connected: ${userId}`);
+    } catch (error) {
+      this.logger.error(`Connection error: ${error.message}`);
+      socket.disconnect();
+    }
+  }
+
+  handleDisconnect(socket: Socket) {
+    try {
+      const userId = this.getUserIdFromSocket(socket);
+      if (userId) {
+        this.clients.delete(userId);
+        this.logger.log(`Client disconnected: ${userId}`);
+      }
+    } catch (error) {
+      this.logger.error(`Disconnection error: ${error.message}`);
+    }
+  }
+
+  @UseGuards(WsJwtAuthGuard)
+  @SubscribeMessage('join')
+  handleJoin(socket: Socket) {
+    try {
+      const userId = this.getUserIdFromSocket(socket);
+      if (userId) {
+        this.clients.set(userId, socket);
+        this.logger.log(`User ${userId} joined notifications channel`);
+        return { success: true, message: 'Successfully joined notifications channel' };
+      }
+      return { success: false, message: 'Failed to join notifications channel' };
+    } catch (error) {
+      this.logger.error(`Join error: ${error.message}`);
+      return { success: false, message: 'Failed to join notifications channel' };
+    }
+  }
+
+  @UseGuards(WsJwtAuthGuard)
+  @SubscribeMessage('leave')
+  handleLeave(socket: Socket) {
+    try {
+      const userId = this.getUserIdFromSocket(socket);
+      if (userId) {
+        this.clients.delete(userId);
+        this.logger.log(`User ${userId} left notifications channel`);
+        return { success: true, message: 'Successfully left notifications channel' };
+      }
+      return { success: false, message: 'Failed to leave notifications channel' };
+    } catch (error) {
+      this.logger.error(`Leave error: ${error.message}`);
+      return { success: false, message: 'Failed to leave notifications channel' };
+    }
+  }
+
+  sendNotification(userId: number, notification: InAppNotification) {
+    try {
+      const client = this.clients.get(userId);
+      if (client) {
+        client.emit('new-notification', notification);
+        this.logger.log(`Notification sent to user ${userId}`);
+        return true;
+      }
+      this.logger.warn(`User ${userId} is not connected`);
+      return false;
+    } catch (error) {
+      this.logger.error(`Error sending notification: ${error.message}`);
+      return false;
+    }
+  }
+
+  sendSystemNotification(notification: InAppNotification) {
+    try {
+      this.server.emit('system-notification', notification);
+      this.logger.log('System notification broadcasted');
+      return true;
+    } catch (error) {
+      this.logger.error(`Error sending system notification: ${error.message}`);
+      return false;
+    }
+  }
+
+  private getUserIdFromSocket(socket: Socket): number | null {
+    try {
+      // First try to get from authenticated user data
+      if (socket.data?.user?.id) {
+        return socket.data.user.id;
+      }
+      
+      // Fallback to query parameter
+      const userId = Number(socket.handshake.query.userId);
+      return isNaN(userId) ? null : userId;
+    } catch {
+      return null;
+    }
+  }
+} 

--- a/backend/src/in-app-notifications/in-app-notifications.module.ts
+++ b/backend/src/in-app-notifications/in-app-notifications.module.ts
@@ -1,0 +1,23 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { JwtModule } from "@nestjs/jwt";
+import { InAppNotification } from "./entities/in-app-notification.entity";
+import { InAppNotificationsController } from "./in-app-notifications.controller";
+import { InAppNotificationsService } from "./in-app-notifications.service";
+import { InAppNotificationsGateway } from "./in-app-notifications.gateway";
+import { UsersModule } from "../users/users.module";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([InAppNotification]),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+      signOptions: { expiresIn: '1d' },
+    }),
+    UsersModule,
+  ],
+  controllers: [InAppNotificationsController],
+  providers: [InAppNotificationsService, InAppNotificationsGateway],
+  exports: [InAppNotificationsService],
+})
+export class InAppNotificationsModule {}

--- a/backend/src/in-app-notifications/in-app-notifications.service.spec.ts
+++ b/backend/src/in-app-notifications/in-app-notifications.service.spec.ts
@@ -1,0 +1,211 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InAppNotificationsService } from './in-app-notifications.service';
+import { InAppNotification, InAppNotificationType } from './entities/in-app-notification.entity';
+import { UsersService } from '../users/users.service';
+import { InAppNotificationsGateway } from './in-app-notifications.gateway';
+import { NotFoundException } from '@nestjs/common';
+
+describe('InAppNotificationsService', () => {
+  let service: InAppNotificationsService;
+  let repository: Repository<InAppNotification>;
+  let usersService: UsersService;
+  let gateway: InAppNotificationsGateway;
+
+  const mockUser = {
+    id: 1,
+    username: 'testuser',
+  };
+
+  const mockNotification = {
+    id: 1,
+    userId: 1,
+    title: 'Test Notification',
+    message: 'Test Message',
+    type: InAppNotificationType.GENERAL,
+    isRead: false,
+    createdAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InAppNotificationsService,
+        {
+          provide: getRepositoryToken(InAppNotification),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+            count: jest.fn(),
+            createQueryBuilder: jest.fn(() => ({
+              where: jest.fn().mockReturnThis(),
+              andWhere: jest.fn().mockReturnThis(),
+              orderBy: jest.fn().mockReturnThis(),
+              addOrderBy: jest.fn().mockReturnThis(),
+              skip: jest.fn().mockReturnThis(),
+              take: jest.fn().mockReturnThis(),
+              getMany: jest.fn(),
+            })),
+          },
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            findById: jest.fn(),
+            findAll: jest.fn(),
+          },
+        },
+        {
+          provide: InAppNotificationsGateway,
+          useValue: {
+            sendNotification: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<InAppNotificationsService>(InAppNotificationsService);
+    repository = module.get<Repository<InAppNotification>>(getRepositoryToken(InAppNotification));
+    usersService = module.get<UsersService>(UsersService);
+    gateway = module.get<InAppNotificationsGateway>(InAppNotificationsGateway);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a notification successfully', async () => {
+      jest.spyOn(usersService, 'findById').mockResolvedValue(mockUser as any);
+      jest.spyOn(repository, 'create').mockReturnValue(mockNotification as any);
+      jest.spyOn(repository, 'save').mockResolvedValue(mockNotification as any);
+
+      const result = await service.create({
+        userId: 1,
+        title: 'Test Notification',
+        message: 'Test Message',
+      });
+
+      expect(result).toEqual(mockNotification);
+      expect(usersService.findById).toHaveBeenCalledWith(1);
+      expect(repository.create).toHaveBeenCalled();
+      expect(repository.save).toHaveBeenCalled();
+      expect(gateway.sendNotification).toHaveBeenCalledWith(1, mockNotification);
+    });
+
+    it('should throw NotFoundException when user not found', async () => {
+      jest.spyOn(usersService, 'findById').mockResolvedValue(null);
+
+      await expect(
+        service.create({
+          userId: 999,
+          title: 'Test Notification',
+          message: 'Test Message',
+        })
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getUserNotifications', () => {
+    it('should return filtered notifications', async () => {
+      const mockNotifications = [mockNotification];
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockNotifications),
+      };
+
+      jest.spyOn(repository, 'createQueryBuilder').mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getUserNotifications(1, {
+        isRead: false,
+        type: InAppNotificationType.GENERAL,
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(result).toEqual(mockNotifications);
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('notification.userId = :userId', { userId: 1 });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalled();
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('should mark notifications as read', async () => {
+      const now = new Date();
+      jest.spyOn(repository, 'update').mockResolvedValue({ affected: 1 } as any);
+
+      const result = await service.markAsRead({ notificationIds: [1, 2] });
+
+      expect(result).toEqual({ success: true, readAt: expect.any(Date) });
+      expect(repository.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a notification', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockNotification as any);
+      jest.spyOn(repository, 'remove').mockResolvedValue(mockNotification as any);
+
+      const result = await service.delete(1, 1);
+
+      expect(result).toEqual(mockNotification);
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { id: 1, userId: 1 },
+      });
+      expect(repository.remove).toHaveBeenCalledWith(mockNotification);
+    });
+
+    it('should throw NotFoundException when notification not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.delete(999, 1)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getUnreadCount', () => {
+    it('should return count of unread notifications', async () => {
+      jest.spyOn(repository, 'count').mockResolvedValue(5);
+
+      const result = await service.getUnreadCount(1);
+
+      expect(result).toBe(5);
+      expect(repository.count).toHaveBeenCalledWith({
+        where: { userId: 1, isRead: false, isArchived: false },
+      });
+    });
+  });
+
+  describe('createSystemNotification', () => {
+    it('should create system-wide notifications', async () => {
+      const mockUsers = [mockUser];
+      jest.spyOn(usersService, 'findAll').mockResolvedValue(mockUsers as any);
+      jest.spyOn(service, 'create').mockResolvedValue(mockNotification as any);
+
+      const result = await service.createSystemNotification(
+        'System Notification',
+        'System Message',
+        InAppNotificationType.SYSTEM
+      );
+
+      expect(result).toEqual([mockNotification]);
+      expect(usersService.findAll).toHaveBeenCalled();
+      expect(service.create).toHaveBeenCalledWith({
+        userId: mockUser.id,
+        title: 'System Notification',
+        message: 'System Message',
+        type: InAppNotificationType.SYSTEM,
+        priority: 5,
+      });
+    });
+  });
+});

--- a/backend/src/in-app-notifications/in-app-notifications.service.ts
+++ b/backend/src/in-app-notifications/in-app-notifications.service.ts
@@ -1,0 +1,183 @@
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common";
+import { InAppNotification, InAppNotificationType } from "./entities/in-app-notification.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, Between, LessThanOrEqual, MoreThanOrEqual, In } from "typeorm";
+import { UsersService } from "src/users/users.service";
+import { CreateInAppNotificationDto, MarkAsReadDto, ArchiveNotificationsDto } from "./dto/create-in-app-notification.dto";
+import { InAppNotificationsGateway } from "./in-app-notifications.gateway";
+
+@Injectable()
+export class InAppNotificationsService {
+  constructor(
+    @InjectRepository(InAppNotification)
+    private readonly notificationsRepository: Repository<InAppNotification>,
+    private readonly usersService: UsersService,
+    private readonly notificationsGateway: InAppNotificationsGateway,
+  ) {}
+
+  async create(createDto: CreateInAppNotificationDto): Promise<InAppNotification> {
+    try {
+      // Verify user exists
+      const user = await this.usersService.FindByUsername(createDto.userId.toString());
+      if (!user) {
+        throw new NotFoundException(`User with ID ${createDto.userId} not found`);
+      }
+
+      const notification = this.notificationsRepository.create({
+        ...createDto,
+        isRead: false,
+        isArchived: false,
+      });
+
+      const savedNotification = await this.notificationsRepository.save(notification);
+
+      // Send real-time notification
+      this.notificationsGateway.sendNotification(createDto.userId, savedNotification);
+
+      return savedNotification;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new BadRequestException(`Failed to create notification: ${error.message}`);
+    }
+  }
+
+  async getUserNotifications(
+    userId: number,
+    options: {
+      isRead?: boolean;
+      isArchived?: boolean;
+      type?: InAppNotificationType;
+      startDate?: Date;
+      endDate?: Date;
+      limit?: number;
+      offset?: number;
+    } = {},
+  ): Promise<{ notifications: InAppNotification[]; total: number }> {
+    try {
+      const queryBuilder = this.notificationsRepository
+        .createQueryBuilder('notification')
+        .where('notification.userId = :userId', { userId });
+
+      if (options.isRead !== undefined) {
+        queryBuilder.andWhere('notification.isRead = :isRead', { isRead: options.isRead });
+      }
+
+      if (options.isArchived !== undefined) {
+        queryBuilder.andWhere('notification.isArchived = :isArchived', { isArchived: options.isArchived });
+      }
+
+      if (options.type) {
+        queryBuilder.andWhere('notification.type = :type', { type: options.type });
+      }
+
+      if (options.startDate && options.endDate) {
+        queryBuilder.andWhere('notification.createdAt BETWEEN :startDate AND :endDate', {
+          startDate: options.startDate,
+          endDate: options.endDate,
+        });
+      }
+
+      const total = await queryBuilder.getCount();
+
+      if (options.limit) {
+        queryBuilder.take(options.limit);
+      }
+
+      if (options.offset) {
+        queryBuilder.skip(options.offset);
+      }
+
+      queryBuilder.orderBy('notification.createdAt', 'DESC');
+
+      const notifications = await queryBuilder.getMany();
+
+      return { notifications, total };
+    } catch (error) {
+      throw new BadRequestException(`Failed to fetch notifications: ${error.message}`);
+    }
+  }
+
+  async markAsRead(notificationIds: number[]): Promise<void> {
+    try {
+      await this.notificationsRepository.update(
+        { id: In(notificationIds) },
+        { isRead: true, readAt: new Date() },
+      );
+    } catch (error) {
+      throw new BadRequestException(`Failed to mark notifications as read: ${error.message}`);
+    }
+  }
+
+  async markAllAsRead(userId: number): Promise<void> {
+    try {
+      await this.notificationsRepository.update(
+        { userId, isRead: false },
+        { isRead: true, readAt: new Date() },
+      );
+    } catch (error) {
+      throw new BadRequestException(`Failed to mark all notifications as read: ${error.message}`);
+    }
+  }
+
+  async archiveNotifications(notificationIds: number[]): Promise<void> {
+    try {
+      await this.notificationsRepository.update(
+        { id: In(notificationIds) },
+        { isArchived: true, archivedAt: new Date() },
+      );
+    } catch (error) {
+      throw new BadRequestException(`Failed to archive notifications: ${error.message}`);
+    }
+  }
+
+  async delete(id: number): Promise<void> {
+    try {
+      const result = await this.notificationsRepository.delete(id);
+      if (result.affected === 0) {
+        throw new NotFoundException(`Notification with ID ${id} not found`);
+      }
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new BadRequestException(`Failed to delete notification: ${error.message}`);
+    }
+  }
+
+  async getUnreadCount(userId: number): Promise<number> {
+    try {
+      return await this.notificationsRepository.count({
+        where: { userId, isRead: false },
+      });
+    } catch (error) {
+      throw new BadRequestException(`Failed to get unread count: ${error.message}`);
+    }
+  }
+
+  async createSystemNotification(notification: Omit<CreateInAppNotificationDto, 'userId'>): Promise<void> {
+    try {
+      // Get all users
+      const users = await this.usersService.findAll();
+      
+      // Create notifications for all users
+      const notifications = users.map(user => ({
+        ...notification,
+        userId: user.id,
+      }));
+
+      // Save notifications in batches
+      const batchSize = 100;
+      for (let i = 0; i < notifications.length; i += batchSize) {
+        const batch = notifications.slice(i, i + batchSize);
+        await this.notificationsRepository.save(batch);
+      }
+
+      // Broadcast system notification
+      this.notificationsGateway.sendSystemNotification(notification as InAppNotification);
+    } catch (error) {
+      throw new BadRequestException(`Failed to create system notification: ${error.message}`);
+    }
+  }
+}

--- a/backend/test/in-app-notifications.e2e-spec.ts
+++ b/backend/test/in-app-notifications.e2e-spec.ts
@@ -1,0 +1,195 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { InAppNotificationType } from '../src/in-app-notifications/entities/in-app-notification.entity';
+import { JwtService } from '@nestjs/jwt';
+
+describe('InAppNotificationsController (e2e)', () => {
+  let app: INestApplication;
+  let jwtService: JwtService;
+  let authToken: string;
+  let userId: number;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    jwtService = moduleFixture.get<JwtService>(JwtService);
+    await app.init();
+
+    // Create a test user and get auth token
+    const testUser = {
+      id: 1,
+      username: 'testuser',
+      email: 'test@example.com',
+    };
+    authToken = jwtService.sign({ sub: testUser.id, username: testUser.username });
+    userId = testUser.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /in-app-notifications', () => {
+    it('should return user notifications', () => {
+      return request(app.getHttpServer())
+        .get('/in-app-notifications')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBeTruthy();
+        });
+    });
+
+    it('should filter notifications by type', () => {
+      return request(app.getHttpServer())
+        .get('/in-app-notifications')
+        .query({ type: InAppNotificationType.GENERAL })
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBeTruthy();
+          if (res.body.length > 0) {
+            expect(res.body[0].type).toBe(InAppNotificationType.GENERAL);
+          }
+        });
+    });
+  });
+
+  describe('GET /in-app-notifications/unread-count', () => {
+    it('should return unread notifications count', () => {
+      return request(app.getHttpServer())
+        .get('/in-app-notifications/unread-count')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(typeof res.body).toBe('number');
+          expect(res.body).toBeGreaterThanOrEqual(0);
+        });
+    });
+  });
+
+  describe('POST /in-app-notifications', () => {
+    it('should create a new notification', () => {
+      const notificationData = {
+        userId,
+        title: 'Test Notification',
+        message: 'This is a test notification',
+        type: InAppNotificationType.GENERAL,
+      };
+
+      return request(app.getHttpServer())
+        .post('/in-app-notifications')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send(notificationData)
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('id');
+          expect(res.body.title).toBe(notificationData.title);
+          expect(res.body.message).toBe(notificationData.message);
+          expect(res.body.type).toBe(notificationData.type);
+        });
+    });
+
+    it('should validate required fields', () => {
+      return request(app.getHttpServer())
+        .post('/in-app-notifications')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({})
+        .expect(400);
+    });
+  });
+
+  describe('POST /in-app-notifications/system', () => {
+    it('should create a system-wide notification', () => {
+      const systemNotification = {
+        title: 'System Update',
+        message: 'System maintenance scheduled',
+        type: InAppNotificationType.SYSTEM,
+      };
+
+      return request(app.getHttpServer())
+        .post('/in-app-notifications/system')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send(systemNotification)
+        .expect(201)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBeTruthy();
+          expect(res.body.length).toBeGreaterThan(0);
+          expect(res.body[0].type).toBe(InAppNotificationType.SYSTEM);
+        });
+    });
+  });
+
+  describe('PATCH /in-app-notifications/read', () => {
+    it('should mark notifications as read', () => {
+      const markAsReadData = {
+        notificationIds: [1, 2],
+      };
+
+      return request(app.getHttpServer())
+        .patch('/in-app-notifications/read')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send(markAsReadData)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('success', true);
+          expect(res.body).toHaveProperty('readAt');
+        });
+    });
+  });
+
+  describe('PATCH /in-app-notifications/read-all', () => {
+    it('should mark all notifications as read', () => {
+      return request(app.getHttpServer())
+        .patch('/in-app-notifications/read-all')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('success', true);
+          expect(res.body).toHaveProperty('readAt');
+        });
+    });
+  });
+
+  describe('PATCH /in-app-notifications/archive', () => {
+    it('should archive notifications', () => {
+      const archiveData = {
+        notificationIds: [1, 2],
+      };
+
+      return request(app.getHttpServer())
+        .patch('/in-app-notifications/archive')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send(archiveData)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('success', true);
+          expect(res.body).toHaveProperty('archivedAt');
+        });
+    });
+  });
+
+  describe('DELETE /in-app-notifications/:id', () => {
+    it('should delete a notification', () => {
+      return request(app.getHttpServer())
+        .delete('/in-app-notifications/1')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('id', 1);
+        });
+    });
+
+    it('should return 404 for non-existent notification', () => {
+      return request(app.getHttpServer())
+        .delete('/in-app-notifications/999')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(404);
+    });
+  });
+}); 


### PR DESCRIPTION
# 🚀 Feature: Dynamic In-App Notifications Module

## 📌 Description

This PR introduces a fully independent and dynamic **In-App Notifications Module** built with NestJS. It provides real-time WebSocket-based notifications, persistent storage via the database, and REST API support for managing notification data.

---

## ✨ Key Features/changes

- [x] `in-app-notifications` module with complete folder structure
- [x] WebSocket Gateway for real-time delivery (`@nestjs/websockets`)
- [x] NotificationService for creating, storing, and broadcasting messages
- [x] Notification Entity with `isRead`, `type`, `message`, `userId`
- [x] Enums for standardized `InAppNotificationType` (e.g., `WELCOME`, `PROFILE_UPDATE`)
- [x] Dynamic type-safe handling for new notification types
- [x] Swagger documentation for notification endpoints
- [x] Unit tests for services and logic
- [x] E2E tests for real-time delivery and retrieval

---

## 📘 Swagger Documentation

##Checklist
[x] `in-app-notifications` module with complete folder structure
[x] WebSocket Gateway for real-time delivery (`@nestjs/websockets`)
[x] NotificationService for creating, storing, and broadcasting messages
[x] Notification Entity with `isRead`, `type`, `message`, `userId`
[x] Enums for standardized `InAppNotificationType` (e.g., `WELCOME`, `PROFILE_UPDATE`) 
[x] Dynamic type-safe handling for new notification types
[x] Swagger documentation for notification endpoints
[x] Unit tests for services and logic 
[x] E2E tests for real-time delivery and retrieval

### Endpoints:

| Method | Route                            | Description                        |
|--------|----------------------------------|------------------------------------|
| GET    | /notifications/:userId          | Fetch all notifications for a user |
| POST   | /notifications/send             | Create and send a new notification |
| PATCH  | /notifications/:id/mark-as-read | Mark a specific notification read  |

---

## 🧪 Testing

### ✅ Unit Tests

```bash
npm run test in-app-notifications
close #441