### PR TITLE
 Implement standalone badge module with user assignment and retrieval

### DIFF
--- a/backend/src/badge/badge.controller.ts
+++ b/backend/src/badge/badge.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, Post, Body } from '@nestjs/common';
+import { BadgeService } from './badge.service';
+import { AssignBadgeDto } from './dto/assign-badge.dto';
+
+@Controller('badges')
+export class BadgeController {
+  constructor(private readonly badgeService: BadgeService) {}
+
+  @Post('assign')
+  assignBadge(@Body() dto: AssignBadgeDto) {
+    return this.badgeService.assignBadgeToUser(dto);
+  }
+
+  @Get('user/:id')
+  getUserBadges(@Param('id') id: string) {
+    return this.badgeService.getBadgesForUser(+id);
+  }
+}

--- a/backend/src/badge/badge.module.ts
+++ b/backend/src/badge/badge.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Badge } from './entities/badge.entity';
+import { UserBadge } from './entities/user-badge.entity';
+import { BadgeService } from './badge.service';
+import { BadgeController } from './badge.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Badge, UserBadge])],
+  providers: [BadgeService],
+  controllers: [BadgeController],
+})
+export class BadgeModule {}

--- a/backend/src/badge/badge.service.ts
+++ b/backend/src/badge/badge.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Badge } from './entities/badge.entity';
+import { UserBadge } from './entities/user-badge.entity';
+import { AssignBadgeDto } from './dto/assign-badge.dto';
+
+@Injectable()
+export class BadgeService {
+  constructor(
+    @InjectRepository(Badge) private badgeRepo: Repository<Badge>,
+    @InjectRepository(UserBadge) private userBadgeRepo: Repository<UserBadge>,
+  ) {}
+
+  async assignBadgeToUser(dto: AssignBadgeDto): Promise<UserBadge> {
+    const badge = await this.badgeRepo.findOneBy({ id: dto.badgeId });
+    if (!badge) throw new NotFoundException('Badge not found');
+
+    const userBadge = this.userBadgeRepo.create({
+      userId: dto.userId,
+      badge,
+    });
+    return this.userBadgeRepo.save(userBadge);
+  }
+
+  async getBadgesForUser(userId: number): Promise<Badge[]> {
+    const userBadges = await this.userBadgeRepo.find({ where: { userId } });
+    return userBadges.map((ub) => ub.badge);
+  }
+}

--- a/backend/src/badge/dto/assign-badge.dto.ts
+++ b/backend/src/badge/dto/assign-badge.dto.ts
@@ -1,0 +1,4 @@
+export class AssignBadgeDto {
+  userId: number;
+  badgeId: number;
+}

--- a/backend/src/badge/entities/badge.entity.ts
+++ b/backend/src/badge/entities/badge.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  OneToMany,
+} from 'typeorm';
+import { UserBadge } from './user-badge.entity';
+
+@Entity('badges')
+export class Badge {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column()
+  iconUrl: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @OneToMany(() => UserBadge, (userBadge) => userBadge.badge)
+  userBadges: UserBadge[];
+}

--- a/backend/src/badge/entities/user-badge.entity.ts
+++ b/backend/src/badge/entities/user-badge.entity.ts
@@ -1,0 +1,23 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  CreateDateColumn,
+  Column,
+} from 'typeorm';
+import { Badge } from './badge.entity';
+
+@Entity('user_badges')
+export class UserBadge {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @ManyToOne(() => Badge, (badge) => badge.userBadges, { eager: true })
+  badge: Badge;
+
+  @CreateDateColumn()
+  awardedAt: Date;
+}


### PR DESCRIPTION


## Description

This PR introduces a fully standalone `BadgeModule` that enables assigning cosmetic or merit-based badges to users and retrieving their awarded badges. This module is isolated, reusable, and designed to work without dependency on other application modules.

---

## Features

### Entities
- `Badge`:
  - Fields: `id`, `title`, `description`, `iconUrl`, `createdAt`
- `UserBadge`:
  - Join table linking users to badges
  - Tracks: `userId`, `badgeId`, `awardedAt`

###  Service Methods
- `assignBadgeToUser(userId, badgeId)` — assigns a badge to a user
- `getBadgesForUser(userId)` — retrieves all badges assigned to a user

###  API Endpoints

 POST    `/badges/assign`     - Assign a badge to a user     
 GET     `/badges/user/:id`    - Get all badges for a user    

---

## Technical Notes

- Module is completely self-contained with:
  - Its own entities, DTOs, services, controllers, and module class
- Designed for plug-and-play in any NestJS + TypeORM application
- Supports future extensions like badge categories, leaderboard logic, etc.

---


