### PR TITLE
 Feature: Self-contained Time-Locked HintModule

### DIFF
--- a/backend/src/badge/badge.controller.ts
+++ b/backend/src/badge/badge.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, Post, Body } from '@nestjs/common';
+import { BadgeService } from './badge.service';
+import { AssignBadgeDto } from './dto/assign-badge.dto';
+
+@Controller('badges')
+export class BadgeController {
+  constructor(private readonly badgeService: BadgeService) {}
+
+  @Post('assign')
+  assignBadge(@Body() dto: AssignBadgeDto) {
+    return this.badgeService.assignBadgeToUser(dto);
+  }
+
+  @Get('user/:id')
+  getUserBadges(@Param('id') id: string) {
+    return this.badgeService.getBadgesForUser(+id);
+  }
+}

--- a/backend/src/badge/badge.module.ts
+++ b/backend/src/badge/badge.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Badge } from './entities/badge.entity';
+import { UserBadge } from './entities/user-badge.entity';
+import { BadgeService } from './badge.service';
+import { BadgeController } from './badge.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Badge, UserBadge])],
+  providers: [BadgeService],
+  controllers: [BadgeController],
+})
+export class BadgeModule {}

--- a/backend/src/badge/badge.service.ts
+++ b/backend/src/badge/badge.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Badge } from './entities/badge.entity';
+import { UserBadge } from './entities/user-badge.entity';
+import { AssignBadgeDto } from './dto/assign-badge.dto';
+
+@Injectable()
+export class BadgeService {
+  constructor(
+    @InjectRepository(Badge) private badgeRepo: Repository<Badge>,
+    @InjectRepository(UserBadge) private userBadgeRepo: Repository<UserBadge>,
+  ) {}
+
+  async assignBadgeToUser(dto: AssignBadgeDto): Promise<UserBadge> {
+    const badge = await this.badgeRepo.findOneBy({ id: dto.badgeId });
+    if (!badge) throw new NotFoundException('Badge not found');
+
+    const userBadge = this.userBadgeRepo.create({
+      userId: dto.userId,
+      badge,
+    });
+    return this.userBadgeRepo.save(userBadge);
+  }
+
+  async getBadgesForUser(userId: number): Promise<Badge[]> {
+    const userBadges = await this.userBadgeRepo.find({ where: { userId } });
+    return userBadges.map((ub) => ub.badge);
+  }
+}

--- a/backend/src/badge/dto/assign-badge.dto.ts
+++ b/backend/src/badge/dto/assign-badge.dto.ts
@@ -1,0 +1,4 @@
+export class AssignBadgeDto {
+  userId: number;
+  badgeId: number;
+}

--- a/backend/src/badge/entities/badge.entity.ts
+++ b/backend/src/badge/entities/badge.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  OneToMany,
+} from 'typeorm';
+import { UserBadge } from './user-badge.entity';
+
+@Entity('badges')
+export class Badge {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column()
+  iconUrl: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @OneToMany(() => UserBadge, (userBadge) => userBadge.badge)
+  userBadges: UserBadge[];
+}

--- a/backend/src/badge/entities/user-badge.entity.ts
+++ b/backend/src/badge/entities/user-badge.entity.ts
@@ -1,0 +1,23 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  CreateDateColumn,
+  Column,
+} from 'typeorm';
+import { Badge } from './badge.entity';
+
+@Entity('user_badges')
+export class UserBadge {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @ManyToOne(() => Badge, (badge) => badge.userBadges, { eager: true })
+  badge: Badge;
+
+  @CreateDateColumn()
+  awardedAt: Date;
+}

--- a/backend/src/hint/create-hint.dto.ts
+++ b/backend/src/hint/create-hint.dto.ts
@@ -1,0 +1,5 @@
+export class CreateHintDto {
+  puzzleId: string;
+  content: string;
+  unlockTimeInMinutes: number;
+}

--- a/backend/src/hint/hint.controller.ts
+++ b/backend/src/hint/hint.controller.ts
@@ -1,0 +1,29 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  BadRequestException,
+} from '@nestjs/common';
+import { HintService } from './hint.service';
+
+@Controller('hints')
+export class HintController {
+  constructor(private readonly hintService: HintService) {}
+
+  @Get(':puzzleId')
+  async getHints(
+    @Param('puzzleId') puzzleId: string,
+    @Query('startTime') startTime: string,
+  ) {
+    if (!startTime)
+      throw new BadRequestException('startTime query param is required');
+
+    const start = new Date(startTime).getTime();
+    const now = Date.now();
+    if (isNaN(start)) throw new BadRequestException('Invalid startTime format');
+
+    const elapsedMinutes = Math.floor((now - start) / 60000);
+    return this.hintService.getAvailableHints(puzzleId, elapsedMinutes);
+  }
+}

--- a/backend/src/hint/hint.entity.ts
+++ b/backend/src/hint/hint.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Hint {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  puzzleId: string;
+
+  @Column()
+  content: string;
+
+  @Column()
+  unlockTimeInMinutes: number;
+}

--- a/backend/src/hint/hint.module.ts
+++ b/backend/src/hint/hint.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Hint } from './hint.entity';
+import { HintService } from './hint.service';
+import { HintController } from './hint.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Hint])],
+  providers: [HintService],
+  controllers: [HintController],
+})
+export class HintModule {}

--- a/backend/src/hint/hint.service.ts
+++ b/backend/src/hint/hint.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Hint } from './hint.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class HintService {
+  constructor(
+    @InjectRepository(Hint)
+    private hintRepository: Repository<Hint>,
+  ) {}
+
+  async create(data: Partial<Hint>) {
+    const hint = this.hintRepository.create(data);
+    return this.hintRepository.save(hint);
+  }
+
+  async getAvailableHints(
+    puzzleId: string,
+    elapsedMinutes: number,
+  ): Promise<Hint[]> {
+    const hints = await this.hintRepository.find({
+      where: { puzzleId },
+      order: { unlockTimeInMinutes: 'ASC' },
+    });
+
+    return hints.filter((hint) => hint.unlockTimeInMinutes <= elapsedMinutes);
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces a fully self-contained `HintModule` that manages time-locked hints for puzzles without any dependency on puzzle, user, or game modules. It allows retrieval of hints that unlock based on elapsed time since the start of a puzzle.

---

##  Changes

- Added `Hint` entity with:
  - `id: number`
  - `puzzleId: string`
  - `content: string`
  - `unlockTimeInMinutes: number`
- Implemented `HintService` to:
  - Create new hints
  - Retrieve available hints based on elapsed time
- Created `HintController` with:
  - `GET /hints/:puzzleId?startTime=<ISO8601>` to simulate puzzle start time
- Configured `HintModule` to be fully modular and reusable
- Uses TypeORM for persistence, no external dependencies

---

closes #458 

