### PR TITLE
implement session-module to track player session

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import appConfig from 'config/app.config';
 import databaseConfig from 'config/database.config';
+import { SessionModule } from './session/session.module';
 
 @Module({
   imports: [
@@ -31,12 +32,9 @@ import databaseConfig from 'config/database.config';
         autoLoadEntities: configService.get('database.autoload'),
       }),
     }),
+    SessionModule,
   ],
   controllers: [AppController],
-  providers: [
-    
-    AppService,
-    
-  ],
+  providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/session/session.controller.ts
+++ b/backend/src/session/session.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Post, Body, Param, Get } from '@nestjs/common';
+import { SessionService } from './session.service';
+import { Session } from './session.entity';
+import { ActivityType } from './enum/activityType.enum';
+
+@Controller('sessions')
+export class SessionController {
+  constructor(private readonly sessionService: SessionService) {}
+
+  @Post('start')
+  async startSession(
+    @Body('userId') userId: string,
+    @Body('activityType') activityType: ActivityType,
+  ): Promise<Session> {
+    return this.sessionService.startSession(userId, activityType);
+  }
+
+  @Post('end/:sessionId')
+  async endSession(
+    @Param('sessionId') sessionId: string,
+  ): Promise<Session | null> {
+    return this.sessionService.endSession(sessionId);
+  }
+
+  @Get('active')
+  async getActiveSessions(): Promise<Session[]> {
+    return this.sessionService.getActiveSessions();
+  }
+}

--- a/backend/src/session/session.entity.ts
+++ b/backend/src/session/session.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { ActivityType } from './enum/activityType.enum';
+
+@Entity('sessions')
+export class Session {
+  @PrimaryGeneratedColumn('uuid')
+  sessionId: string;
+
+  @Column({ type: 'uuid' })
+  @Index()
+  userId: string;
+
+  @Column({ type: 'enum', enum: ActivityType })
+  activityType: ActivityType;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  startedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  endedAt: Date | null;
+}

--- a/backend/src/session/session.module.ts
+++ b/backend/src/session/session.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
+import { Session } from './session.entity';
+import { SessionService } from './session.service';
+import { SessionController } from './session.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Session]), ScheduleModule.forRoot()],
+  providers: [SessionService],
+  controllers: [SessionController],
+  exports: [SessionService],
+})
+export class SessionModule {}

--- a/backend/src/session/session.service.ts
+++ b/backend/src/session/session.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { Session } from './session.entity';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ActivityType } from './enum/activityType.enum';
+
+@Injectable()
+export class SessionService {
+  private readonly logger = new Logger(SessionService.name);
+
+  constructor(
+    @InjectRepository(Session)
+    private readonly sessionRepository: Repository<Session>,
+  ) {}
+
+  async startSession(
+    userId: string,
+    activityType: ActivityType,
+  ): Promise<Session> {
+    const session = this.sessionRepository.create({
+      userId,
+      activityType,
+      startedAt: new Date(),
+      endedAt: null,
+    });
+    return this.sessionRepository.save(session);
+  }
+
+  async endSession(sessionId: string): Promise<Session | null> {
+    const session = await this.sessionRepository.findOne({
+      where: { sessionId },
+    });
+    if (!session) return null;
+    session.endedAt = new Date();
+    return this.sessionRepository.save(session);
+  }
+
+  async getActiveSessions(): Promise<Session[]> {
+    return this.sessionRepository.find({ where: { endedAt: null } });
+  }
+
+  // Cleanup sessions ended more than 24 hours ago (customize as needed)
+  @Cron(CronExpression.EVERY_HOUR)
+  async cleanupExpiredSessions() {
+    const expiryDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const result = await this.sessionRepository.delete({
+      endedAt: LessThan(expiryDate),
+    });
+    if (result.affected) {
+      this.logger.log(`Cleaned up ${result.affected} expired sessions.`);
+    }
+  }
+}


### PR DESCRIPTION
Session entity with all required fields (sessionId, userId, activityType, startedAt, endedAt).
SessionModule is standalone, with no imports or coupling to other modules.
SessionService for session creation, termination, and automatic cleanup (using cron via @nestjs/schedule).
SessionController for starting, ending, and listing active sessions.
Module is pluggable and testable in isolation.