### PR TITLE
feat: implement standalone TimeTrialModule for timed puzzle challenges

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import appConfig from 'config/app.config';
 import databaseConfig from 'config/database.config';
 import { PuzzleModule } from './puzzle/puzzle.module';
 import { PuzzleSubmissionModule } from './puzzle-submission/puzzle-submission.module';
+import { TimeTrialModule } from './time-trial/time-trial.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { PuzzleSubmissionModule } from './puzzle-submission/puzzle-submission.mo
     }),
     PuzzleModule,
     PuzzleSubmissionModule,
+    TimeTrialModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/time-trial/providers/timetrial.service.ts
+++ b/backend/src/time-trial/providers/timetrial.service.ts
@@ -1,0 +1,55 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { TimeTrial } from '../time-trial.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class TimetrialService {
+    constructor(
+    @InjectRepository(TimeTrial)
+    private trialRepo: Repository<TimeTrial>,
+  ) {}
+
+  async startTrial(userId: string, puzzleId: string): Promise<TimeTrial> {
+    const trial = this.trialRepo.create({
+      userId,
+      puzzleId,
+      startTime: new Date(),
+    });
+    return await this.trialRepo.save(trial);
+  }
+
+  async submitTrial(id: string): Promise<TimeTrial> {
+    const trial = await this.trialRepo.findOne({ where: { id } });
+    if (!trial) throw new NotFoundException('Trial not found');
+
+    const endTime = new Date();
+    const timeLimitInMinutes = 5; // configurable
+    const diff = (endTime.getTime() - new Date(trial.startTime).getTime()) / 60000;
+
+    if (diff > timeLimitInMinutes) {
+      throw new BadRequestException('Time limit exceeded');
+    }
+
+    trial.endTime = endTime;
+    trial.completed = true;
+    return await this.trialRepo.save(trial);
+  }
+
+  async getResults(userId: string): Promise<TimeTrial[]> {
+    return await this.trialRepo.find({
+      where: { userId },
+      relations: ['puzzle'],
+      order: { endTime: 'DESC' },
+    });
+  }
+
+  // Optional: basic leaderboard logic
+  async getLeaderboard(puzzleId: string): Promise<TimeTrial[]> {
+    return await this.trialRepo.find({
+      where: { puzzleId, completed: true },
+      order: { endTime: 'ASC' },
+      take: 10,
+    });
+  }
+}

--- a/backend/src/time-trial/time-trial.controller.ts
+++ b/backend/src/time-trial/time-trial.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { TimetrialService } from './providers/timetrial.service';
+
+@Controller('time-trial')
+export class TimeTrialController {
+      constructor(private readonly timeTrialService: TimetrialService) {}
+
+  @Post('start')
+  startTrial(@Body() body: { userId: string; puzzleId: string }) {
+    return this.timeTrialService.startTrial(body.userId, body.puzzleId);
+  }
+
+  @Post('submit/:id')
+  submitTrial(@Param('id') id: string) {
+    return this.timeTrialService.submitTrial(id);
+  }
+
+  @Get('results/:userId')
+  getUserResults(@Param('userId') userId: string) {
+    return this.timeTrialService.getResults(userId);
+  }
+
+  @Get('leaderboard/:puzzleId')
+  getLeaderboard(@Param('puzzleId') puzzleId: string) {
+    return this.timeTrialService.getLeaderboard(puzzleId);
+  }
+}

--- a/backend/src/time-trial/time-trial.controller.ts
+++ b/backend/src/time-trial/time-trial.controller.ts
@@ -1,26 +1,87 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { TimetrialService } from './providers/timetrial.service';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
+@ApiTags('Time Trials')
 @Controller('time-trial')
 export class TimeTrialController {
-      constructor(private readonly timeTrialService: TimetrialService) {}
+  constructor(private readonly timeTrialService: TimetrialService) {}
 
   @Post('start')
+  @ApiOperation({ summary: 'Start a new time trial for a puzzle' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        userId: { type: 'string', example: 'user-123' },
+        puzzleId: { type: 'string', example: 'puzzle-456' },
+      },
+      required: ['userId', 'puzzleId'],
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Time trial started successfully',
+  })
   startTrial(@Body() body: { userId: string; puzzleId: string }) {
     return this.timeTrialService.startTrial(body.userId, body.puzzleId);
   }
 
   @Post('submit/:id')
+  @ApiOperation({ summary: 'Submit a time trial attempt' })
+  @ApiParam({
+    name: 'id',
+    description: 'TimeTrial ID',
+    example: 'trial-789',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Time trial submission recorded and validated',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Time limit exceeded or trial invalid',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Time trial not found',
+  })
   submitTrial(@Param('id') id: string) {
     return this.timeTrialService.submitTrial(id);
   }
 
   @Get('results/:userId')
+  @ApiOperation({ summary: 'Get all time trial results for a user' })
+  @ApiParam({
+    name: 'userId',
+    description: 'User ID to fetch results for',
+    example: 'user-123',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of time trials completed by the user',
+  })
   getUserResults(@Param('userId') userId: string) {
     return this.timeTrialService.getResults(userId);
   }
 
   @Get('leaderboard/:puzzleId')
+  @ApiOperation({ summary: 'Get top 10 fastest completions for a puzzle' })
+  @ApiParam({
+    name: 'puzzleId',
+    description: 'Puzzle ID to get leaderboard for',
+    example: 'puzzle-456',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Top performers for the specified puzzle',
+  })
   getLeaderboard(@Param('puzzleId') puzzleId: string) {
     return this.timeTrialService.getLeaderboard(puzzleId);
   }

--- a/backend/src/time-trial/time-trial.entity.ts
+++ b/backend/src/time-trial/time-trial.entity.ts
@@ -1,0 +1,46 @@
+import { Puzzle } from 'src/puzzle/puzzle.entity';
+import { User } from 'src/puzzle/puzzle.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity()
+export class TimeTrial {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  userId: string;
+
+  @Column()
+  @Index()
+  puzzleId: string;
+
+  @ManyToOne(() => User, user => user.timeTrials)
+  user: User;
+
+  @ManyToOne(() => Puzzle, puzzle => puzzle.timeTrials)
+  puzzle: Puzzle;
+
+  @Column({ type: 'timestamp' })
+  startTime: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  endTime: Date;
+
+  @Column({ default: false })
+  completed: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/time-trial/time-trial.module.ts
+++ b/backend/src/time-trial/time-trial.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TimetrialService } from './providers/timetrial.service';
+import { TimeTrialController } from './time-trial.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TimeTrial } from './time-trial.entity';
+
+@Module({
+  imports:[TypeOrmModule.forFeature([TimeTrial])],
+  providers: [TimetrialService],
+  controllers: [TimeTrialController],
+  exports: [TimetrialService]
+})
+export class TimeTrialModule {}


### PR DESCRIPTION
Closes issue #478 
Description:
This PR introduces the TimeTrialModule, enabling a special game mode for users to solve puzzles within a fixed time window. It encourages quick thinking and rewards fast solvers.

Includes:

TimeTrial entity and schema with relations

Service logic for starting and submitting trials

RESTful endpoints to manage time trials

Time-based validation and optional leaderboard

Indexing and proper relationship mapping

Acceptance Criteria Met:

[x] Entity created with necessary fields and relations

[x] Time tracking and submission logic implemented

[x] Controller endpoints functional

[x] Leaderboard available per puzzle

[x] Works independently but can integrate with global leaderboard