### PR TITLE
feat(leaderboard): add standalone LeaderboardModule 

### DIFF
--- a/backend/src/leaderboard/leaderboard.controller.ts
+++ b/backend/src/leaderboard/leaderboard.controller.ts
@@ -1,0 +1,49 @@
+import { Controller, Get, Query, Req, Res, HttpStatus } from '@nestjs/common';
+import { LeaderboardService } from './leaderboard.service';
+import type { Response, Request } from 'express';
+
+// Simple in-memory rate limiter
+const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX = 30; // 30 requests per window per IP
+const rateLimitMap = new Map<string, { count: number; timestamp: number }>();
+
+function rateLimit(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+  if (!entry || now - entry.timestamp > RATE_LIMIT_WINDOW) {
+    rateLimitMap.set(ip, { count: 1, timestamp: now });
+    return false;
+  }
+  if (entry.count >= RATE_LIMIT_MAX) {
+    return true;
+  }
+  entry.count++;
+  return false;
+}
+
+@Controller('leaderboard')
+export class LeaderboardController {
+  constructor(private readonly leaderboardService: LeaderboardService) {}
+
+  @Get()
+  async getLeaderboard(
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '10',
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const ip = req.ip || req.headers['x-forwarded-for'] || 'unknown';
+    if (rateLimit(ip as string)) {
+      return res.status(HttpStatus.TOO_MANY_REQUESTS).json({ message: 'Rate limit exceeded' });
+    }
+    const pageNum = Math.max(1, parseInt(page as string, 10) || 1);
+    const sizeNum = Math.max(1, Math.min(100, parseInt(pageSize as string, 10) || 10));
+    const { entries, total } = this.leaderboardService.getLeaderboard(pageNum, sizeNum);
+    return res.status(HttpStatus.OK).json({
+      data: entries,
+      page: pageNum,
+      pageSize: sizeNum,
+      total,
+    });
+  }
+} 

--- a/backend/src/leaderboard/leaderboard.module.ts
+++ b/backend/src/leaderboard/leaderboard.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LeaderboardService } from './leaderboard.service';
+import { LeaderboardController } from './leaderboard.controller';
+
+@Module({
+  controllers: [LeaderboardController],
+  providers: [LeaderboardService],
+  exports: [LeaderboardService],
+})
+export class LeaderboardModule {} 

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+
+export interface LeaderboardUser {
+  userId: string;
+  username: string;
+  points: number;
+  puzzlesSolved: number;
+}
+
+export interface LeaderboardEntry extends LeaderboardUser {
+  rank: number;
+}
+
+@Injectable()
+export class LeaderboardService {
+  private users: LeaderboardUser[] = [];
+  private leaderboardCache: LeaderboardEntry[] = [];
+  private cacheTimestamp: number = 0;
+  private readonly CACHE_TTL = 60 * 1000; // 1 minute
+  private readonly TOP_N = 100;
+
+  // For demonstration, add or update a user's score
+  upsertUser(user: LeaderboardUser) {
+    const idx = this.users.findIndex(u => u.userId === user.userId);
+    if (idx !== -1) {
+      this.users[idx] = user;
+    } else {
+      this.users.push(user);
+    }
+    this.invalidateCache();
+  }
+
+  // Aggregate, sort, and rank users
+  private computeLeaderboard(): LeaderboardEntry[] {
+    const sorted = [...this.users].sort((a, b) => {
+      // Sort by points, then puzzlesSolved, then username
+      if (b.points !== a.points) return b.points - a.points;
+      if (b.puzzlesSolved !== a.puzzlesSolved) return b.puzzlesSolved - a.puzzlesSolved;
+      return a.username.localeCompare(b.username);
+    });
+    return sorted.slice(0, this.TOP_N).map((user, i) => ({ ...user, rank: i + 1 }));
+  }
+
+  // Get leaderboard with caching
+  getLeaderboard(page = 1, pageSize = 10): { entries: LeaderboardEntry[]; total: number } {
+    const now = Date.now();
+    if (!this.leaderboardCache.length || now - this.cacheTimestamp > this.CACHE_TTL) {
+      this.leaderboardCache = this.computeLeaderboard();
+      this.cacheTimestamp = now;
+    }
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    return {
+      entries: this.leaderboardCache.slice(start, end),
+      total: this.leaderboardCache.length,
+    };
+  }
+
+  // Invalidate cache when data changes
+  private invalidateCache() {
+    this.leaderboardCache = [];
+    this.cacheTimestamp = 0;
+  }
+} 


### PR DESCRIPTION
with global ranking, caching, and API endpoint

- Implements LeaderboardService for user score aggregation, sorting, and in-memory caching of top 100 users
- Adds LeaderboardController with paginated GET /leaderboard endpoint and basic rate limiting
- Ensures module is fully standalone and does not depend on other modules