### PR TITLE
feat: implement standalone puzzle comment module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,7 @@ import { User } from "./auth/entities/user.entity"
 import { TimeTrial } from "./time-trial/time-trial.entity"
 import { Puzzle } from "./puzzle/puzzle.entity"
 import { Category } from "./puzzle-category/entities/category.entity"
+import { PuzzleCommentModule } from './puzzle-comment/puzzle-comment.module';
 
 @Module({
   imports: [
@@ -58,6 +59,7 @@ import { Category } from "./puzzle-category/entities/category.entity"
     TimeTrialModule,
     InAppNotificationsModule,
     NFTClaimModule,
+    PuzzleCommentModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/puzzle-comment/dto/create-puzzle-comment.dto.ts
+++ b/backend/src/puzzle-comment/dto/create-puzzle-comment.dto.ts
@@ -1,0 +1,1 @@
+export class CreatePuzzleCommentDto {}

--- a/backend/src/puzzle-comment/dto/update-puzzle-comment.dto.ts
+++ b/backend/src/puzzle-comment/dto/update-puzzle-comment.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePuzzleCommentDto } from './create-puzzle-comment.dto';
+
+export class UpdatePuzzleCommentDto extends PartialType(CreatePuzzleCommentDto) {}

--- a/backend/src/puzzle-comment/entities/puzzle-comment.entity.ts
+++ b/backend/src/puzzle-comment/entities/puzzle-comment.entity.ts
@@ -1,0 +1,1 @@
+export class PuzzleComment {}

--- a/backend/src/puzzle-comment/puzzle-comment.controller.spec.ts
+++ b/backend/src/puzzle-comment/puzzle-comment.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PuzzleCommentController } from './puzzle-comment.controller';
+import { PuzzleCommentService } from './puzzle-comment.service';
+
+describe('PuzzleCommentController', () => {
+  let controller: PuzzleCommentController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PuzzleCommentController],
+      providers: [PuzzleCommentService],
+    }).compile();
+
+    controller = module.get<PuzzleCommentController>(PuzzleCommentController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/puzzle-comment/puzzle-comment.controller.ts
+++ b/backend/src/puzzle-comment/puzzle-comment.controller.ts
@@ -1,0 +1,110 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Delete,
+  Put,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Query,
+} from '@nestjs/common';
+import { PuzzleCommentService, PuzzleComment } from './puzzle-comment.service';
+import { IsString, IsNotEmpty, IsBoolean, IsOptional } from 'class-validator';
+
+class CreateCommentDto {
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+
+  @IsNotEmpty()
+  @IsString()
+  puzzleId: string;
+
+  @IsNotEmpty()
+  @IsString()
+  commentText: string;
+}
+
+class AdminActionDto {
+  @IsNotEmpty()
+  @IsBoolean()
+  isAdmin: boolean;
+}
+
+@Controller('puzzle-comments')
+export class PuzzleCommentController {
+  private readonly logger = new Logger(PuzzleCommentController.name);
+
+  constructor(private readonly puzzleCommentService: PuzzleCommentService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  createComment(@Body() createCommentDto: CreateCommentDto): PuzzleComment {
+    this.logger.log(
+      `Received request to create comment: ${JSON.stringify(createCommentDto)}`,
+    );
+    const { userId, puzzleId, commentText } = createCommentDto;
+    return this.puzzleCommentService.createComment(
+      userId,
+      puzzleId,
+      commentText,
+    );
+  }
+
+  @Get('puzzle/:puzzleId')
+  getCommentsForPuzzle(@Param('puzzleId') puzzleId: string): PuzzleComment[] {
+    this.logger.log(`Received request for comments on puzzle ${puzzleId}.`);
+    return this.puzzleCommentService.getCommentsForPuzzle(puzzleId);
+  }
+
+  @Get('flagged')
+  getFlaggedComments(): PuzzleComment[] {
+    this.logger.log('Received request for flagged comments.');
+    return this.puzzleCommentService.getFlaggedComments();
+  }
+
+  @Put(':commentId/flag')
+  flagComment(
+    @Param('commentId') commentId: string,
+    @Body() adminActionDto: AdminActionDto,
+  ): PuzzleComment {
+    this.logger.log(
+      `Received request to flag comment ${commentId} (isAdmin: ${adminActionDto.isAdmin}).`,
+    );
+    return this.puzzleCommentService.flagComment(
+      commentId,
+      adminActionDto.isAdmin,
+    );
+  }
+
+  @Put(':commentId/unflag')
+  unflagComment(
+    @Param('commentId') commentId: string,
+    @Body() adminActionDto: AdminActionDto,
+  ): PuzzleComment {
+    this.logger.log(
+      `Received request to unflag comment ${commentId} (isAdmin: ${adminActionDto.isAdmin}).`,
+    );
+    return this.puzzleCommentService.unflagComment(
+      commentId,
+      adminActionDto.isAdmin,
+    );
+  }
+
+  @Delete(':commentId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  deleteComment(
+    @Param('commentId') commentId: string,
+    @Query('userId') userId: string,
+    @Query('isAdmin') isAdminString: string,
+  ): void {
+    const isAdmin = isAdminString === 'true';
+    this.logger.log(
+      `Received request to delete comment ${commentId} by user ${userId} (isAdmin: ${isAdmin}).`,
+    );
+    this.puzzleCommentService.deleteComment(commentId, userId, isAdmin);
+  }
+}

--- a/backend/src/puzzle-comment/puzzle-comment.module.ts
+++ b/backend/src/puzzle-comment/puzzle-comment.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PuzzleCommentService } from './puzzle-comment.service';
+import { PuzzleCommentController } from './puzzle-comment.controller';
+
+@Module({
+  providers: [PuzzleCommentService],
+  controllers: [PuzzleCommentController],
+  exports: [PuzzleCommentService],
+})
+export class PuzzleCommentModule {}

--- a/backend/src/puzzle-comment/puzzle-comment.service.spec.ts
+++ b/backend/src/puzzle-comment/puzzle-comment.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PuzzleCommentService } from './puzzle-comment.service';
+
+describe('PuzzleCommentService', () => {
+  let service: PuzzleCommentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PuzzleCommentService],
+    }).compile();
+
+    service = module.get<PuzzleCommentService>(PuzzleCommentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/puzzle-comment/puzzle-comment.service.ts
+++ b/backend/src/puzzle-comment/puzzle-comment.service.ts
@@ -1,0 +1,174 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+
+export interface PuzzleComment {
+  id: string;
+  userId: string;
+  puzzleId: string;
+  commentText: string;
+  timestamp: Date;
+  isFlagged: boolean;
+}
+
+@Injectable()
+export class PuzzleCommentService {
+  private readonly logger = new Logger(PuzzleCommentService.name);
+
+  private comments = new Map<string, PuzzleComment>();
+  private commentCounter = 0;
+
+  private userCommentTimestamps = new Map<string, Map<string, number[]>>(); // Map<userId, Map<puzzleId, [timestamp1, timestamp2, ...]>>
+
+  private readonly RATE_LIMIT_COUNT = 3;
+  private readonly RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour in milliseconds
+
+  constructor() {
+    this.seedData();
+  }
+
+  private seedData(): void {
+    this.logger.log('Seeding initial puzzle comment data...');
+    this.createComment(
+      'user1',
+      'puzzle101',
+      'Great puzzle, really enjoyed it!',
+    );
+    this.createComment('user2', 'puzzle101', 'A bit challenging, but fun!');
+    this.createComment('user1', 'puzzle102', 'This one was tricky!');
+    const flaggedComment = this.createComment(
+      'user3',
+      'puzzle101',
+      'This comment is inappropriate.',
+    );
+    if (flaggedComment) {
+      flaggedComment.isFlagged = true;
+      this.comments.set(flaggedComment.id, flaggedComment);
+    }
+    this.logger.log(`Seeded ${this.comments.size} comments.`);
+  }
+
+  private checkRateLimit(userId: string, puzzleId: string): void {
+    if (!this.userCommentTimestamps.has(userId)) {
+      this.userCommentTimestamps.set(userId, new Map<string, number[]>());
+    }
+    const userPuzzles = this.userCommentTimestamps.get(userId);
+
+    if (!userPuzzles.has(puzzleId)) {
+      userPuzzles.set(puzzleId, []);
+    }
+    const timestamps = userPuzzles.get(puzzleId);
+
+    const now = Date.now();
+    const windowStart = now - this.RATE_LIMIT_WINDOW_MS;
+
+    const recentTimestamps = timestamps.filter((ts) => ts > windowStart);
+
+    if (recentTimestamps.length >= this.RATE_LIMIT_COUNT) {
+      this.logger.warn(
+        `Rate limit exceeded for user ${userId} on puzzle ${puzzleId}.`,
+      );
+      throw new ForbiddenException(
+        `You can only post ${this.RATE_LIMIT_COUNT} comments per hour on this puzzle.`,
+      );
+    }
+
+    timestamps.push(now);
+    userPuzzles.set(puzzleId, timestamps);
+  }
+
+  createComment(
+    userId: string,
+    puzzleId: string,
+    commentText: string,
+  ): PuzzleComment {
+    this.logger.log(
+      `Attempting to create comment by user ${userId} on puzzle ${puzzleId}.`,
+    );
+    this.checkRateLimit(userId, puzzleId);
+
+    if (!commentText || commentText.trim().length === 0) {
+      throw new BadRequestException('Comment text cannot be empty.');
+    }
+
+    this.commentCounter++;
+    const newComment: PuzzleComment = {
+      id: `comment-${this.commentCounter}`,
+      userId,
+      puzzleId,
+      commentText,
+      timestamp: new Date(),
+      isFlagged: false,
+    };
+    this.comments.set(newComment.id, newComment);
+    this.logger.log(`Comment created: ${JSON.stringify(newComment)}`);
+    return newComment;
+  }
+
+  getCommentsForPuzzle(puzzleId: string): PuzzleComment[] {
+    this.logger.log(`Fetching comments for puzzle ${puzzleId}.`);
+    return Array.from(this.comments.values()).filter(
+      (comment) => comment.puzzleId === puzzleId,
+    );
+  }
+
+  getFlaggedComments(): PuzzleComment[] {
+    this.logger.log('Fetching all flagged comments.');
+    return Array.from(this.comments.values()).filter(
+      (comment) => comment.isFlagged,
+    );
+  }
+
+  flagComment(commentId: string, isAdmin: boolean): PuzzleComment {
+    if (!isAdmin) {
+      throw new ForbiddenException('Only administrators can flag comments.');
+    }
+    this.logger.log(`Attempting to flag comment ${commentId}.`);
+    const comment = this.comments.get(commentId);
+    if (!comment) {
+      throw new NotFoundException(`Comment with ID "${commentId}" not found.`);
+    }
+    comment.isFlagged = true;
+    this.comments.set(commentId, comment);
+    this.logger.log(`Comment ${commentId} flagged.`);
+    return comment;
+  }
+
+  unflagComment(commentId: string, isAdmin: boolean): PuzzleComment {
+    if (!isAdmin) {
+      throw new ForbiddenException('Only administrators can unflag comments.');
+    }
+    this.logger.log(`Attempting to unflag comment ${commentId}.`);
+    const comment = this.comments.get(commentId);
+    if (!comment) {
+      throw new NotFoundException(`Comment with ID "${commentId}" not found.`);
+    }
+    comment.isFlagged = false;
+    this.comments.set(commentId, comment);
+    this.logger.log(`Comment ${commentId} unflagged.`);
+    return comment;
+  }
+
+  deleteComment(commentId: string, userId: string, isAdmin: boolean): void {
+    this.logger.log(
+      `Attempting to delete comment ${commentId} by user ${userId} (isAdmin: ${isAdmin}).`,
+    );
+    const comment = this.comments.get(commentId);
+    if (!comment) {
+      throw new NotFoundException(`Comment with ID "${commentId}" not found.`);
+    }
+
+    if (comment.userId !== userId && !isAdmin) {
+      throw new ForbiddenException(
+        'You are not authorized to delete this comment.',
+      );
+    }
+
+    this.comments.delete(commentId);
+    this.logger.log(`Comment ${commentId} deleted.`);
+  }
+}


### PR DESCRIPTION
This PR implements the  `PuzzleCommentModule` to enable user comments on puzzles.

**Changes Made:**
- **PuzzleComment Entity:** Define the structure for user comments, including user ID, puzzle ID, comment text, timestamp, and a flag for moderation.
- **Rate Limiting:** Implements per-user rate limiting (3 comments per hour per puzzle) to prevent spam.
- **Admin Moderation:** Adds an `isFlagged` field and corresponding logic for administrators to flag and unflag inappropriate comments. Users can only delete their own comments, while admins can delete any.
- **API Endpoints:** Provides a comprehensive API for:
    - Creating new comments.
    - Retrieving comments for a specific puzzle.
    - Listing all flagged comments for moderation.
    - Flagging/unflagging comments (admin only).
    - Deleting comments (user's own or admin).

Closes #533 