### PR TITLE
feat: implement api key module

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -62,6 +62,7 @@
         "@types/node": "^20.17.57",
         "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.0",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^8.0.0",
@@ -3030,6 +3031,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "13.12.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -74,6 +74,7 @@
     "@types/node": "^20.17.57",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.0",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.0.0",

--- a/backend/src/api-key/api-key.controller.spec.ts
+++ b/backend/src/api-key/api-key.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApiKeyController } from './api-key.controller';
+import { ApiKeyService } from './api-key.service';
+
+describe('ApiKeyController', () => {
+  let controller: ApiKeyController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ApiKeyController],
+      providers: [ApiKeyService],
+    }).compile();
+
+    controller = module.get<ApiKeyController>(ApiKeyController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/api-key/api-key.controller.ts
+++ b/backend/src/api-key/api-key.controller.ts
@@ -1,0 +1,94 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  Get,
+  Param,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Query,
+} from '@nestjs/common';
+import { ApiKeyService, ApiKey, ApiKeyStatus } from './api-key.service';
+import {
+  IsString,
+  IsNotEmpty,
+  IsBoolean,
+  IsOptional,
+  IsDateString,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { APIKeyGuard } from './api-key.guard';
+
+class GenerateApiKeyDto {
+  @IsNotEmpty()
+  @IsString()
+  ownerLabel: string;
+
+  @IsNotEmpty()
+  @IsBoolean()
+  isAdmin: boolean;
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string;
+}
+
+class AdminActionDto {
+  @IsNotEmpty()
+  @IsBoolean()
+  isAdmin: boolean;
+}
+
+@Controller('api-keys')
+export class ApiKeyController {
+  private readonly logger = new Logger(ApiKeyController.name);
+
+  constructor(private readonly apiKeyService: ApiKeyService) {}
+
+  @Post('generate')
+  @HttpCode(HttpStatus.CREATED)
+  generateApiKey(@Body() generateApiKeyDto: GenerateApiKeyDto): ApiKey {
+    this.logger.log(
+      `Received request to generate API key: ${JSON.stringify(generateApiKeyDto)}`,
+    );
+    return this.apiKeyService.generateApiKey(
+      generateApiKeyDto.ownerLabel,
+      generateApiKeyDto.isAdmin,
+      generateApiKeyDto.expiresAt
+        ? new Date(generateApiKeyDto.expiresAt)
+        : undefined,
+    );
+  }
+
+  @Post('revoke/:key')
+  @HttpCode(HttpStatus.OK)
+  revokeApiKey(
+    @Param('key') key: string,
+    @Body() adminActionDto: AdminActionDto,
+  ): ApiKey {
+    this.logger.log(
+      `Received request to revoke API key ${key} (isAdmin: ${adminActionDto.isAdmin}).`,
+    );
+    return this.apiKeyService.revokeApiKey(key, adminActionDto.isAdmin);
+  }
+
+  @Get('all')
+  getAllApiKeys(@Query() adminActionDto: AdminActionDto): ApiKey[] {
+    this.logger.log(
+      `Received request to get all API keys (isAdmin: ${adminActionDto.isAdmin}).`,
+    );
+    return this.apiKeyService.getAllApiKeys(adminActionDto.isAdmin);
+  }
+
+  @Get('protected')
+  @UseGuards(APIKeyGuard)
+  @HttpCode(HttpStatus.OK)
+  getProtectedData(): { message: string } {
+    this.logger.log('Accessing protected route.');
+    return {
+      message: 'This is protected data, accessible only with a valid API key!',
+    };
+  }
+}

--- a/backend/src/api-key/api-key.guard.ts
+++ b/backend/src/api-key/api-key.guard.ts
@@ -1,0 +1,35 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { ApiKeyService } from './api-key.service';
+
+@Injectable()
+export class APIKeyGuard implements CanActivate {
+  private readonly logger = new Logger(APIKeyGuard.name);
+
+  constructor(private apiKeyService: ApiKeyService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const apiKey = request.headers['x-api-key'] as string;
+
+    if (!apiKey) {
+      this.logger.warn('API Key missing from headers.');
+      throw new UnauthorizedException('API Key missing');
+    }
+
+    const isValid = this.apiKeyService.validateApiKey(apiKey);
+
+    if (!isValid) {
+      this.logger.warn(`Invalid API Key: ${apiKey}`);
+      throw new UnauthorizedException('Invalid API Key');
+    }
+
+    return true;
+  }
+}

--- a/backend/src/api-key/api-key.module.ts
+++ b/backend/src/api-key/api-key.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ApiKeyService } from './api-key.service';
+import { ApiKeyController } from './api-key.controller';
+
+@Module({
+  providers: [ApiKeyService],
+  controllers: [ApiKeyController],
+  exports: [ApiKeyService],
+})
+export class ApiKeyModule {}

--- a/backend/src/api-key/api-key.service.spec.ts
+++ b/backend/src/api-key/api-key.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApiKeyService } from './api-key.service';
+
+describe('ApiKeyService', () => {
+  let service: ApiKeyService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ApiKeyService],
+    }).compile();
+
+    service = module.get<ApiKeyService>(ApiKeyService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/api-key/api-key.service.ts
+++ b/backend/src/api-key/api-key.service.ts
@@ -1,0 +1,121 @@
+import {
+  Injectable,
+  Logger,
+  UnauthorizedException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+
+export enum ApiKeyStatus {
+  ACTIVE = 'active',
+  REVOKED = 'revoked',
+}
+
+export interface ApiKey {
+  key: string;
+  ownerLabel: string;
+  status: ApiKeyStatus;
+  createdAt: Date;
+  expiresAt?: Date;
+}
+
+@Injectable()
+export class ApiKeyService {
+  private readonly logger = new Logger(ApiKeyService.name);
+
+  private apiKeys = new Map<string, ApiKey>();
+
+  constructor() {
+    this.seedData();
+  }
+
+  private seedData(): void {
+    this.logger.log('Seeding initial API key data...');
+    this.generateApiKey(
+      'admin-key-owner',
+      true,
+      new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+    ); // Valid for 1 year
+    this.generateApiKey('test-key-owner', true); // No expiration
+    this.logger.log(`Seeded ${this.apiKeys.size} API keys.`);
+  }
+
+  generateApiKey(
+    ownerLabel: string,
+    isAdmin: boolean,
+    expiresAt?: Date,
+  ): ApiKey {
+    if (!isAdmin) {
+      throw new UnauthorizedException(
+        'Only administrators can generate API keys.',
+      );
+    }
+    if (!ownerLabel || ownerLabel.trim().length === 0) {
+      throw new BadRequestException('Owner label cannot be empty.');
+    }
+
+    const newKey = uuidv4();
+    const apiKey: ApiKey = {
+      key: newKey,
+      ownerLabel,
+      status: ApiKeyStatus.ACTIVE,
+      createdAt: new Date(),
+      expiresAt,
+    };
+    this.apiKeys.set(newKey, apiKey);
+    this.logger.log(`Generated new API key for ${ownerLabel}: ${newKey}`);
+    return apiKey;
+  }
+
+  revokeApiKey(key: string, isAdmin: boolean): ApiKey {
+    if (!isAdmin) {
+      throw new UnauthorizedException(
+        'Only administrators can revoke API keys.',
+      );
+    }
+
+    const apiKey = this.apiKeys.get(key);
+    if (!apiKey) {
+      throw new NotFoundException(`API Key "${key}" not found.`);
+    }
+    if (apiKey.status === ApiKeyStatus.REVOKED) {
+      throw new BadRequestException(`API Key "${key}" is already revoked.`);
+    }
+
+    apiKey.status = ApiKeyStatus.REVOKED;
+    this.apiKeys.set(key, apiKey);
+    this.logger.log(`API Key "${key}" revoked.`);
+    return apiKey;
+  }
+
+  validateApiKey(key: string): boolean {
+    this.logger.log(`Validating API Key: ${key}`);
+    const apiKey = this.apiKeys.get(key);
+
+    if (!apiKey) {
+      this.logger.warn(`API Key "${key}" not found.`);
+      return false;
+    }
+    if (apiKey.status === ApiKeyStatus.REVOKED) {
+      this.logger.warn(`API Key "${key}" is revoked.`);
+      return false;
+    }
+    if (apiKey.expiresAt && apiKey.expiresAt < new Date()) {
+      this.logger.warn(`API Key "${key}" has expired.`);
+      return false;
+    }
+
+    this.logger.log(`API Key "${key}" is valid.`);
+    return true;
+  }
+
+  getAllApiKeys(isAdmin: boolean): ApiKey[] {
+    if (!isAdmin) {
+      throw new UnauthorizedException(
+        'Only administrators can view all API keys.',
+      );
+    }
+    return Array.from(this.apiKeys.values());
+  }
+}

--- a/backend/src/api-key/dto/create-api-key.dto.ts
+++ b/backend/src/api-key/dto/create-api-key.dto.ts
@@ -1,0 +1,1 @@
+export class CreateApiKeyDto {}

--- a/backend/src/api-key/dto/update-api-key.dto.ts
+++ b/backend/src/api-key/dto/update-api-key.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateApiKeyDto } from './create-api-key.dto';
+
+export class UpdateApiKeyDto extends PartialType(CreateApiKeyDto) {}

--- a/backend/src/api-key/entities/api-key.entity.ts
+++ b/backend/src/api-key/entities/api-key.entity.ts
@@ -1,0 +1,1 @@
+export class ApiKey {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,7 @@ import { User } from "./auth/entities/user.entity"
 import { TimeTrial } from "./time-trial/time-trial.entity"
 import { Puzzle } from "./puzzle/puzzle.entity"
 import { Category } from "./puzzle-category/entities/category.entity"
+import { ApiKeyModule } from './api-key/api-key.module';
 
 @Module({
   imports: [
@@ -58,6 +59,7 @@ import { Category } from "./puzzle-category/entities/category.entity"
     TimeTrialModule,
     InAppNotificationsModule,
     NFTClaimModule,
+    ApiKeyModule,
   ],
   controllers: [AppController],
   providers: [AppService],


### PR DESCRIPTION
This PR introduces the `APIKeyModule` to manage internal API key access for securing sensitive routes or services.

**Changes Made:**
- **ApiKey Entity:** Defined the structure for API keys, including the key string, owner label, status (active/revoked), creation timestamp, and optional expiration date.
- **Admin-Only Logic:** Implemented logic for administrators to generate and revoke API keys, ensuring secure management.
- **APIKeyGuard:** Provided a NestJS guard that verifies incoming requests carry valid and active API keys in the `x-api-key` header, restricting access to protected routes.
- **API Endpoints:** Exposed endpoints for:
    - Generating new API keys (admin only).
    - Revoking existing API keys (admin only).
    - Listing all API keys (admin only).
    - A protected route demonstrating guard functionality.

Closes #534 