### PR TITLE
✨ Implement Standalone Content Rating Module with Aggregation Endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,8 @@ import { AnalyticsModule } from './analytics/analytics.module';
 import { RewardShopModule } from './reward-shop/reward-shop.module';
 import { ApiKeyModule } from './api-key/api-key.module';
 import { UserRankingModule } from './user-ranking/user-ranking.module';
+import { ContentRatingModule } from './content-rating/content-rating.module';
+
 
 @Module({
   imports: [
@@ -64,6 +66,7 @@ import { UserRankingModule } from './user-ranking/user-ranking.module';
     UserReactionModule,
     MultiplayerQueueModule,
     UserRankingModule,
+    ContentRatingModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/content-rating/content-rating.controller.spec.ts
+++ b/backend/src/content-rating/content-rating.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContentRatingController } from './content-rating.controller';
+
+describe('ContentRatingController', () => {
+  let controller: ContentRatingController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ContentRatingController],
+    }).compile();
+
+    controller = module.get<ContentRatingController>(ContentRatingController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/content-rating/content-rating.controller.ts
+++ b/backend/src/content-rating/content-rating.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { ContentRatingService } from './content-rating.service';
+import { CreateRatingDto } from './dto/create-rating.dto';
+
+@Controller('ratings')
+export class ContentRatingController {
+  constructor(private readonly ratingService: ContentRatingService) {}
+
+  @Post()
+  async rateContent(@Body() dto: CreateRatingDto) {
+    return this.ratingService.rateContent(dto.userId, dto.contentId, dto.rating);
+  }
+
+  @Get('/stats')
+  async getStats(@Query('contentId') contentId: string) {
+    return this.ratingService.getContentRatingStats(contentId);
+  }
+}

--- a/backend/src/content-rating/content-rating.module.ts
+++ b/backend/src/content-rating/content-rating.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContentRating } from './entities/content-rating.entity';
+import { ContentRatingService } from './content-rating.service';
+import { ContentRatingController } from './content-rating.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ContentRating])],
+  controllers: [ContentRatingController],
+  providers: [ContentRatingService],
+})
+export class ContentRatingModule {}

--- a/backend/src/content-rating/content-rating.service.spec.ts
+++ b/backend/src/content-rating/content-rating.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContentRatingService } from './content-rating.service';
+
+describe('ContentRatingService', () => {
+  let service: ContentRatingService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ContentRatingService],
+    }).compile();
+
+    service = module.get<ContentRatingService>(ContentRatingService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/content-rating/content-rating.service.ts
+++ b/backend/src/content-rating/content-rating.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ContentRating } from './entities/content-rating.entity';
+
+@Injectable()
+export class ContentRatingService {
+  constructor(
+    @InjectRepository(ContentRating)
+    private readonly ratingRepo: Repository<ContentRating>,
+  ) {}
+
+  async rateContent(userId: string, contentId: string, rating: number) {
+    try {
+      const newRating = this.ratingRepo.create({ userId, contentId, rating });
+      return await this.ratingRepo.save(newRating);
+    } catch (error) {
+      if (error.code === '23505') {
+        // Unique constraint violation
+        throw new ConflictException('User has already rated this content.');
+      }
+      throw error;
+    }
+  }
+
+  async getContentRatingStats(contentId: string) {
+    const { avg, count } = await this.ratingRepo
+      .createQueryBuilder('rating')
+      .select('AVG(rating.rating)', 'avg')
+      .addSelect('COUNT(rating.id)', 'count')
+      .where('rating.contentId = :contentId', { contentId })
+      .getRawOne();
+
+    return {
+      contentId,
+      averageRating: parseFloat(avg) || 0,
+      totalRatings: parseInt(count) || 0,
+    };
+  }
+}

--- a/backend/src/content-rating/dto/create-rating.dto.ts
+++ b/backend/src/content-rating/dto/create-rating.dto.ts
@@ -1,0 +1,14 @@
+import { IsInt, IsString, Max, Min } from 'class-validator';
+
+export class CreateRatingDto {
+  @IsString()
+  userId: string;
+
+  @IsString()
+  contentId: string;
+
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating: number;
+}

--- a/backend/src/content-rating/entities/content-rating.entity.ts
+++ b/backend/src/content-rating/entities/content-rating.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  Unique,
+  ManyToOne,
+  Index,
+} from 'typeorm';
+
+@Entity('content_ratings')
+@Unique(['userId', 'contentId']) // Enforces one rating per user per content
+export class ContentRating {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  userId: string;
+
+  @Column()
+  @Index()
+  contentId: string;
+
+  @Column('int')
+  rating: number; // Typically from 1 to 5
+
+  @CreateDateColumn()
+  createdAt: Date;
+}


### PR DESCRIPTION
### 📌 Summary

This PR introduces a self-contained `ContentRatingModule` that allows users to rate educational content and retrieves content quality metrics based on these ratings.

---

### ✅ Features Implemented

- 📦 `ContentRating` entity capturing:
  - `userId`
  - `contentId`
  - `rating` (1–5)
  - `createdAt`
- 🔒 Enforced one rating per user per content item using a unique constraint
- 🛠️ Service logic to:
  - Save new ratings
  - Handle duplicate rating attempts
  - Compute average rating and total number of ratings for any content
- 🌐 REST API:
  - `POST /ratings`: Submit a new rating
  - `GET /ratings/stats?contentId=...`: Fetch aggregate statistics
- ✅ Input validation using DTOs and class-validator

---

### 🧪 How to Test

1. **POST /ratings**
   ```json
   {
     "userId": "user123",
     "contentId": "content456",
     "rating": 5
   }

### 🧪 Closing
closes #504 