### PR TITLE
implement GeoStats module with DTO, service, controller

### DIFF
--- a/backend/src/geostats/dto/create-geostat.dto.ts
+++ b/backend/src/geostats/dto/create-geostat.dto.ts
@@ -1,0 +1,7 @@
+import { IsIP, IsNotEmpty } from 'class-validator';
+
+export class CreateGeoStatDto {
+  @IsNotEmpty()
+  @IsIP()
+  ipAddress: string;
+}

--- a/backend/src/geostats/entities/geostat.entity.ts
+++ b/backend/src/geostats/entities/geostat.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('geostats')
+export class GeoStats {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  ipAddress: string;
+
+  @Column()
+  country: string;
+
+  @CreateDateColumn()
+  timestamp: Date;
+}

--- a/backend/src/geostats/geostats.controller.ts
+++ b/backend/src/geostats/geostats.controller.ts
@@ -1,0 +1,19 @@
+
+import { Controller, Post, Get, Ip } from '@nestjs/common';
+import { GeoStatsService } from './geostats.service';
+
+@Controller('geostats')
+export class GeoStatsController {
+  constructor(private readonly geoStatsService: GeoStatsService) {}
+
+  @Post('track')
+  track(@Ip() ip: string) {
+    
+    return this.geoStatsService.trackUser(ip);
+  }
+
+  @Get('stats')
+  getStats() {
+    return this.geoStatsService.getStats();
+  }
+}

--- a/backend/src/geostats/geostats.module.ts
+++ b/backend/src/geostats/geostats.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpModule } from '@nestjs/axios';
+import { GeoStats } from './entities/geostat.entity';
+import { GeoStatsService } from './geostats.service';
+import { GeoStatsController } from './geostats.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([GeoStats]), HttpModule],
+  providers: [GeoStatsService],
+  controllers: [GeoStatsController],
+})
+export class GeoStatsModule {}

--- a/backend/src/geostats/geostats.service.ts
+++ b/backend/src/geostats/geostats.service.ts
@@ -1,0 +1,48 @@
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GeoStats } from './entities/geostat.entity';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class GeoStatsService {
+  constructor(
+    @InjectRepository(GeoStats)
+    private readonly geoStatsRepository: Repository<GeoStats>,
+    private readonly httpService: HttpService,
+  ) {}
+
+  async trackUser(ipAddress: string): Promise<GeoStats> {
+    try {
+      const { data } = await firstValueFrom(
+        this.httpService.get(`http://ip-api.com/json/${ipAddress}`),
+      );
+
+      const newGeoStat = this.geoStatsRepository.create({
+        ipAddress,
+        country: data.country || 'Unknown',
+      });
+
+      return await this.geoStatsRepository.save(newGeoStat);
+    } catch (error) {
+      console.error('Error resolving IP address:', error);
+      
+      const newGeoStat = this.geoStatsRepository.create({
+        ipAddress,
+        country: 'Unknown',
+      });
+      return await this.geoStatsRepository.save(newGeoStat);
+    }
+  }
+
+  async getStats(): Promise<{ country: string; userCount: string }[]> {
+    return this.geoStatsRepository
+      .createQueryBuilder('geostats')
+      .select('country')
+      .addSelect('COUNT(DISTINCT "ipAddress")', 'userCount')
+      .groupBy('country')
+      .getRawMany();
+  }
+}


### PR DESCRIPTION
Added a standalone GeoStatsModule to track and aggregate user location data (IP, country, timestamp) for analytics.

Features
Stores IP, country, timestamp
Uses public IP-to-country service

Public API:
- POST /geostats/track
- GET /geostats/stats

closes #529 