### PR TITLE
Dailyreward

### DIFF
--- a/backend/src/daily-reward/daily-reward.controller.spec.ts
+++ b/backend/src/daily-reward/daily-reward.controller.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DailyRewardController } from './daily-reward.controller';
+import { DailyRewardService } from './daily-reward.service';
+import { DailyCheckinDto } from './dto/daily-checkin.dto';
+
+describe('DailyRewardController', () => {
+  let controller: DailyRewardController;
+  let service: DailyRewardService;
+
+  const mockDailyRewardService = {
+    dailyCheckIn: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DailyRewardController],
+      providers: [
+        {
+          provide: DailyRewardService,
+          useValue: mockDailyRewardService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DailyRewardController>(DailyRewardController);
+    service = module.get<DailyRewardService>(DailyRewardService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('dailyCheckIn', () => {
+    it('should call the dailyCheckIn service with the correct userId', async () => {
+      const dto: DailyCheckinDto = { userId: 'user-123' };
+      const expectedResult = { id: 'uuid', userId: dto.userId, streak: 1, timestamp: new Date() };
+      mockDailyRewardService.dailyCheckIn.mockResolvedValue(expectedResult);
+
+      const result = await controller.dailyCheckIn(dto);
+
+      expect(service.dailyCheckIn).toHaveBeenCalledWith(dto.userId);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});

--- a/backend/src/daily-reward/daily-reward.controller.ts
+++ b/backend/src/daily-reward/daily-reward.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Post, Body, UsePipes, ValidationPipe } from '@nestjs/common';
+import { DailyRewardService } from './daily-reward.service';
+import { DailyCheckinDto } from './dto/daily-checkin.dto';
+
+@Controller('rewards')
+export class DailyRewardController {
+  constructor(private readonly dailyRewardService: DailyRewardService) {}
+
+  @Post('daily-checkin')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  dailyCheckIn(@Body() dailyCheckinDto: DailyCheckinDto) {
+    return this.dailyRewardService.dailyCheckIn(dailyCheckinDto.userId);
+  }
+}

--- a/backend/src/daily-reward/daily-reward.module.ts
+++ b/backend/src/daily-reward/daily-reward.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DailyRewardLog } from './entities/daily-reward-log.entity';
+import { DailyRewardService } from './daily-reward.service';
+import { DailyRewardController } from './daily-reward.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DailyRewardLog])],
+  providers: [DailyRewardService],
+  controllers: [DailyRewardController],
+})
+export class DailyRewardModule {}

--- a/backend/src/daily-reward/daily-reward.service.spec.ts
+++ b/backend/src/daily-reward/daily-reward.service.spec.ts
@@ -1,0 +1,89 @@
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { DailyRewardService } from './daily-reward.service';
+import { DailyRewardLog } from './entities/daily-reward-log.entity';
+
+describe('DailyRewardService', () => {
+  let service: DailyRewardService;
+  let repo: Repository<DailyRewardLog>;
+
+  const mockRewardLogRepository = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DailyRewardService,
+        {
+          provide: getRepositoryToken(DailyRewardLog),
+          useValue: mockRewardLogRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DailyRewardService>(DailyRewardService);
+    repo = module.get<Repository<DailyRewardLog>>(getRepositoryToken(DailyRewardLog));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('dailyCheckIn', () => {
+    const userId = 'user-123';
+
+    it('should start a streak at 1 for the first check-in', async () => {
+      mockRewardLogRepository.findOne.mockResolvedValue(null);
+      mockRewardLogRepository.create.mockReturnValue({ userId, streak: 1 });
+      mockRewardLogRepository.save.mockResolvedValue({ id: 'uuid', userId, streak: 1, timestamp: new Date() });
+
+      const result = await service.dailyCheckIn(userId);
+
+      expect(repo.create).toHaveBeenCalledWith({ userId, streak: 1 });
+      expect(result.streak).toBe(1);
+    });
+
+    it('should throw a ConflictException if already checked in today', async () => {
+      const today = new Date();
+      mockRewardLogRepository.findOne.mockResolvedValue({ userId, streak: 3, timestamp: today });
+
+      await expect(service.dailyCheckIn(userId)).rejects.toThrow(ConflictException);
+    });
+
+    it('should continue a streak if the last check-in was yesterday', async () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const lastCheckIn = { userId, streak: 3, timestamp: yesterday };
+      
+      mockRewardLogRepository.findOne.mockResolvedValue(lastCheckIn);
+      mockRewardLogRepository.create.mockReturnValue({ userId, streak: 4 });
+      mockRewardLogRepository.save.mockResolvedValue({ id: 'uuid', userId, streak: 4, timestamp: new Date() });
+
+      const result = await service.dailyCheckIn(userId);
+
+      expect(repo.create).toHaveBeenCalledWith({ userId, streak: 4 });
+      expect(result.streak).toBe(4);
+    });
+
+    it('should reset a streak if the last check-in was before yesterday', async () => {
+      const twoDaysAgo = new Date();
+      twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+      const lastCheckIn = { userId, streak: 5, timestamp: twoDaysAgo };
+
+      mockRewardLogRepository.findOne.mockResolvedValue(lastCheckIn);
+      mockRewardLogRepository.create.mockReturnValue({ userId, streak: 1 });
+      mockRewardLogRepository.save.mockResolvedValue({ id: 'uuid', userId, streak: 1, timestamp: new Date() });
+
+      const result = await service.dailyCheckIn(userId);
+
+      expect(repo.create).toHaveBeenCalledWith({ userId, streak: 1 });
+      expect(result.streak).toBe(1);
+    });
+  });
+});

--- a/backend/src/daily-reward/daily-reward.service.ts
+++ b/backend/src/daily-reward/daily-reward.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DailyRewardLog } from './entities/daily-reward-log.entity';
+
+@Injectable()
+export class DailyRewardService {
+  constructor(
+    @InjectRepository(DailyRewardLog)
+    private readonly rewardLogRepository: Repository<DailyRewardLog>,
+  ) {}
+
+  async dailyCheckIn(userId: string): Promise<DailyRewardLog> {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); 
+
+    const lastCheckIn = await this.rewardLogRepository.findOne({
+      where: { userId },
+      order: { timestamp: 'DESC' },
+    });
+
+    
+    if (lastCheckIn) {
+      const lastCheckInDate = new Date(lastCheckIn.timestamp);
+      lastCheckInDate.setHours(0, 0, 0, 0); 
+
+      if (lastCheckInDate.getTime() === today.getTime()) {
+        throw new ConflictException('Reward already claimed for today.');
+      }
+    }
+
+    
+    let currentStreak = 1; 
+    if (lastCheckIn) {
+      const lastCheckInDate = new Date(lastCheckIn.timestamp);
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+      yesterday.setHours(0, 0, 0, 0); 
+      
+      if (lastCheckInDate.getTime() === yesterday.getTime()) {
+        currentStreak = lastCheckIn.streak + 1;
+      }
+      
+    }
+
+    const newLog = this.rewardLogRepository.create({
+      userId,
+      streak: currentStreak,
+    });
+
+    return this.rewardLogRepository.save(newLog);
+  }
+}

--- a/backend/src/daily-reward/dto/daily-checkin.dto.ts
+++ b/backend/src/daily-reward/dto/daily-checkin.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class DailyCheckinDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+}

--- a/backend/src/daily-reward/entities/daily-reward-log.entity.ts
+++ b/backend/src/daily-reward/entities/daily-reward-log.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from 'typeorm';
+
+@Entity('daily_reward_logs')
+export class DailyRewardLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column()
+  userId: string;
+
+  @Column({ default: 1 })
+  streak: number;
+
+  @CreateDateColumn()
+  timestamp: Date;
+}

--- a/backend/src/geostats/dto/create-geostat.dto.ts
+++ b/backend/src/geostats/dto/create-geostat.dto.ts
@@ -1,0 +1,7 @@
+import { IsIP, IsNotEmpty } from 'class-validator';
+
+export class CreateGeoStatDto {
+  @IsNotEmpty()
+  @IsIP()
+  ipAddress: string;
+}

--- a/backend/src/geostats/entities/geostat.entity.ts
+++ b/backend/src/geostats/entities/geostat.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('geostats')
+export class GeoStats {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  ipAddress: string;
+
+  @Column()
+  country: string;
+
+  @CreateDateColumn()
+  timestamp: Date;
+}

--- a/backend/src/geostats/geostats.controller.ts
+++ b/backend/src/geostats/geostats.controller.ts
@@ -1,0 +1,19 @@
+
+import { Controller, Post, Get, Ip } from '@nestjs/common';
+import { GeoStatsService } from './geostats.service';
+
+@Controller('geostats')
+export class GeoStatsController {
+  constructor(private readonly geoStatsService: GeoStatsService) {}
+
+  @Post('track')
+  track(@Ip() ip: string) {
+    
+    return this.geoStatsService.trackUser(ip);
+  }
+
+  @Get('stats')
+  getStats() {
+    return this.geoStatsService.getStats();
+  }
+}

--- a/backend/src/geostats/geostats.module.ts
+++ b/backend/src/geostats/geostats.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpModule } from '@nestjs/axios';
+import { GeoStats } from './entities/geostat.entity';
+import { GeoStatsService } from './geostats.service';
+import { GeoStatsController } from './geostats.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([GeoStats]), HttpModule],
+  providers: [GeoStatsService],
+  controllers: [GeoStatsController],
+})
+export class GeoStatsModule {}

--- a/backend/src/geostats/geostats.service.ts
+++ b/backend/src/geostats/geostats.service.ts
@@ -1,0 +1,48 @@
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GeoStats } from './entities/geostat.entity';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class GeoStatsService {
+  constructor(
+    @InjectRepository(GeoStats)
+    private readonly geoStatsRepository: Repository<GeoStats>,
+    private readonly httpService: HttpService,
+  ) {}
+
+  async trackUser(ipAddress: string): Promise<GeoStats> {
+    try {
+      const { data } = await firstValueFrom(
+        this.httpService.get(`http://ip-api.com/json/${ipAddress}`),
+      );
+
+      const newGeoStat = this.geoStatsRepository.create({
+        ipAddress,
+        country: data.country || 'Unknown',
+      });
+
+      return await this.geoStatsRepository.save(newGeoStat);
+    } catch (error) {
+      console.error('Error resolving IP address:', error);
+      
+      const newGeoStat = this.geoStatsRepository.create({
+        ipAddress,
+        country: 'Unknown',
+      });
+      return await this.geoStatsRepository.save(newGeoStat);
+    }
+  }
+
+  async getStats(): Promise<{ country: string; userCount: string }[]> {
+    return this.geoStatsRepository
+      .createQueryBuilder('geostats')
+      .select('country')
+      .addSelect('COUNT(DISTINCT "ipAddress")', 'userCount')
+      .groupBy('country')
+      .getRawMany();
+  }
+}


### PR DESCRIPTION
Implemented a self-contained DailyRewardModule for daily user check-ins with streak tracking and 24h cooldown.

Features
Tracks check-ins and streaks via DailyRewardLog
Enforces 24-hour cooldown

POST /rewards/daily-checkin returns reward + streak info

closes #528 
