### PR TITLE
Puzzlefork

### DIFF
--- a/backend/src/daily-reward/daily-reward.controller.spec.ts
+++ b/backend/src/daily-reward/daily-reward.controller.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DailyRewardController } from './daily-reward.controller';
+import { DailyRewardService } from './daily-reward.service';
+import { DailyCheckinDto } from './dto/daily-checkin.dto';
+
+describe('DailyRewardController', () => {
+  let controller: DailyRewardController;
+  let service: DailyRewardService;
+
+  const mockDailyRewardService = {
+    dailyCheckIn: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DailyRewardController],
+      providers: [
+        {
+          provide: DailyRewardService,
+          useValue: mockDailyRewardService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DailyRewardController>(DailyRewardController);
+    service = module.get<DailyRewardService>(DailyRewardService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('dailyCheckIn', () => {
+    it('should call the dailyCheckIn service with the correct userId', async () => {
+      const dto: DailyCheckinDto = { userId: 'user-123' };
+      const expectedResult = { id: 'uuid', userId: dto.userId, streak: 1, timestamp: new Date() };
+      mockDailyRewardService.dailyCheckIn.mockResolvedValue(expectedResult);
+
+      const result = await controller.dailyCheckIn(dto);
+
+      expect(service.dailyCheckIn).toHaveBeenCalledWith(dto.userId);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});

--- a/backend/src/daily-reward/daily-reward.controller.ts
+++ b/backend/src/daily-reward/daily-reward.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Post, Body, UsePipes, ValidationPipe } from '@nestjs/common';
+import { DailyRewardService } from './daily-reward.service';
+import { DailyCheckinDto } from './dto/daily-checkin.dto';
+
+@Controller('rewards')
+export class DailyRewardController {
+  constructor(private readonly dailyRewardService: DailyRewardService) {}
+
+  @Post('daily-checkin')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  dailyCheckIn(@Body() dailyCheckinDto: DailyCheckinDto) {
+    return this.dailyRewardService.dailyCheckIn(dailyCheckinDto.userId);
+  }
+}

--- a/backend/src/daily-reward/daily-reward.module.ts
+++ b/backend/src/daily-reward/daily-reward.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DailyRewardLog } from './entities/daily-reward-log.entity';
+import { DailyRewardService } from './daily-reward.service';
+import { DailyRewardController } from './daily-reward.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DailyRewardLog])],
+  providers: [DailyRewardService],
+  controllers: [DailyRewardController],
+})
+export class DailyRewardModule {}

--- a/backend/src/daily-reward/daily-reward.service.spec.ts
+++ b/backend/src/daily-reward/daily-reward.service.spec.ts
@@ -1,0 +1,89 @@
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { DailyRewardService } from './daily-reward.service';
+import { DailyRewardLog } from './entities/daily-reward-log.entity';
+
+describe('DailyRewardService', () => {
+  let service: DailyRewardService;
+  let repo: Repository<DailyRewardLog>;
+
+  const mockRewardLogRepository = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DailyRewardService,
+        {
+          provide: getRepositoryToken(DailyRewardLog),
+          useValue: mockRewardLogRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DailyRewardService>(DailyRewardService);
+    repo = module.get<Repository<DailyRewardLog>>(getRepositoryToken(DailyRewardLog));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('dailyCheckIn', () => {
+    const userId = 'user-123';
+
+    it('should start a streak at 1 for the first check-in', async () => {
+      mockRewardLogRepository.findOne.mockResolvedValue(null);
+      mockRewardLogRepository.create.mockReturnValue({ userId, streak: 1 });
+      mockRewardLogRepository.save.mockResolvedValue({ id: 'uuid', userId, streak: 1, timestamp: new Date() });
+
+      const result = await service.dailyCheckIn(userId);
+
+      expect(repo.create).toHaveBeenCalledWith({ userId, streak: 1 });
+      expect(result.streak).toBe(1);
+    });
+
+    it('should throw a ConflictException if already checked in today', async () => {
+      const today = new Date();
+      mockRewardLogRepository.findOne.mockResolvedValue({ userId, streak: 3, timestamp: today });
+
+      await expect(service.dailyCheckIn(userId)).rejects.toThrow(ConflictException);
+    });
+
+    it('should continue a streak if the last check-in was yesterday', async () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const lastCheckIn = { userId, streak: 3, timestamp: yesterday };
+      
+      mockRewardLogRepository.findOne.mockResolvedValue(lastCheckIn);
+      mockRewardLogRepository.create.mockReturnValue({ userId, streak: 4 });
+      mockRewardLogRepository.save.mockResolvedValue({ id: 'uuid', userId, streak: 4, timestamp: new Date() });
+
+      const result = await service.dailyCheckIn(userId);
+
+      expect(repo.create).toHaveBeenCalledWith({ userId, streak: 4 });
+      expect(result.streak).toBe(4);
+    });
+
+    it('should reset a streak if the last check-in was before yesterday', async () => {
+      const twoDaysAgo = new Date();
+      twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+      const lastCheckIn = { userId, streak: 5, timestamp: twoDaysAgo };
+
+      mockRewardLogRepository.findOne.mockResolvedValue(lastCheckIn);
+      mockRewardLogRepository.create.mockReturnValue({ userId, streak: 1 });
+      mockRewardLogRepository.save.mockResolvedValue({ id: 'uuid', userId, streak: 1, timestamp: new Date() });
+
+      const result = await service.dailyCheckIn(userId);
+
+      expect(repo.create).toHaveBeenCalledWith({ userId, streak: 1 });
+      expect(result.streak).toBe(1);
+    });
+  });
+});

--- a/backend/src/daily-reward/daily-reward.service.ts
+++ b/backend/src/daily-reward/daily-reward.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DailyRewardLog } from './entities/daily-reward-log.entity';
+
+@Injectable()
+export class DailyRewardService {
+  constructor(
+    @InjectRepository(DailyRewardLog)
+    private readonly rewardLogRepository: Repository<DailyRewardLog>,
+  ) {}
+
+  async dailyCheckIn(userId: string): Promise<DailyRewardLog> {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); 
+
+    const lastCheckIn = await this.rewardLogRepository.findOne({
+      where: { userId },
+      order: { timestamp: 'DESC' },
+    });
+
+    
+    if (lastCheckIn) {
+      const lastCheckInDate = new Date(lastCheckIn.timestamp);
+      lastCheckInDate.setHours(0, 0, 0, 0); 
+
+      if (lastCheckInDate.getTime() === today.getTime()) {
+        throw new ConflictException('Reward already claimed for today.');
+      }
+    }
+
+    
+    let currentStreak = 1; 
+    if (lastCheckIn) {
+      const lastCheckInDate = new Date(lastCheckIn.timestamp);
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+      yesterday.setHours(0, 0, 0, 0); 
+      
+      if (lastCheckInDate.getTime() === yesterday.getTime()) {
+        currentStreak = lastCheckIn.streak + 1;
+      }
+      
+    }
+
+    const newLog = this.rewardLogRepository.create({
+      userId,
+      streak: currentStreak,
+    });
+
+    return this.rewardLogRepository.save(newLog);
+  }
+}

--- a/backend/src/daily-reward/dto/daily-checkin.dto.ts
+++ b/backend/src/daily-reward/dto/daily-checkin.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class DailyCheckinDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+}

--- a/backend/src/daily-reward/entities/daily-reward-log.entity.ts
+++ b/backend/src/daily-reward/entities/daily-reward-log.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from 'typeorm';
+
+@Entity('daily_reward_logs')
+export class DailyRewardLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column()
+  userId: string;
+
+  @Column({ default: 1 })
+  streak: number;
+
+  @CreateDateColumn()
+  timestamp: Date;
+}

--- a/backend/src/geostats/dto/create-geostat.dto.ts
+++ b/backend/src/geostats/dto/create-geostat.dto.ts
@@ -1,0 +1,7 @@
+import { IsIP, IsNotEmpty } from 'class-validator';
+
+export class CreateGeoStatDto {
+  @IsNotEmpty()
+  @IsIP()
+  ipAddress: string;
+}

--- a/backend/src/geostats/entities/geostat.entity.ts
+++ b/backend/src/geostats/entities/geostat.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('geostats')
+export class GeoStats {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  ipAddress: string;
+
+  @Column()
+  country: string;
+
+  @CreateDateColumn()
+  timestamp: Date;
+}

--- a/backend/src/geostats/geostats.controller.ts
+++ b/backend/src/geostats/geostats.controller.ts
@@ -1,0 +1,19 @@
+
+import { Controller, Post, Get, Ip } from '@nestjs/common';
+import { GeoStatsService } from './geostats.service';
+
+@Controller('geostats')
+export class GeoStatsController {
+  constructor(private readonly geoStatsService: GeoStatsService) {}
+
+  @Post('track')
+  track(@Ip() ip: string) {
+    
+    return this.geoStatsService.trackUser(ip);
+  }
+
+  @Get('stats')
+  getStats() {
+    return this.geoStatsService.getStats();
+  }
+}

--- a/backend/src/geostats/geostats.module.ts
+++ b/backend/src/geostats/geostats.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpModule } from '@nestjs/axios';
+import { GeoStats } from './entities/geostat.entity';
+import { GeoStatsService } from './geostats.service';
+import { GeoStatsController } from './geostats.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([GeoStats]), HttpModule],
+  providers: [GeoStatsService],
+  controllers: [GeoStatsController],
+})
+export class GeoStatsModule {}

--- a/backend/src/geostats/geostats.service.ts
+++ b/backend/src/geostats/geostats.service.ts
@@ -1,0 +1,48 @@
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GeoStats } from './entities/geostat.entity';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class GeoStatsService {
+  constructor(
+    @InjectRepository(GeoStats)
+    private readonly geoStatsRepository: Repository<GeoStats>,
+    private readonly httpService: HttpService,
+  ) {}
+
+  async trackUser(ipAddress: string): Promise<GeoStats> {
+    try {
+      const { data } = await firstValueFrom(
+        this.httpService.get(`http://ip-api.com/json/${ipAddress}`),
+      );
+
+      const newGeoStat = this.geoStatsRepository.create({
+        ipAddress,
+        country: data.country || 'Unknown',
+      });
+
+      return await this.geoStatsRepository.save(newGeoStat);
+    } catch (error) {
+      console.error('Error resolving IP address:', error);
+      
+      const newGeoStat = this.geoStatsRepository.create({
+        ipAddress,
+        country: 'Unknown',
+      });
+      return await this.geoStatsRepository.save(newGeoStat);
+    }
+  }
+
+  async getStats(): Promise<{ country: string; userCount: string }[]> {
+    return this.geoStatsRepository
+      .createQueryBuilder('geostats')
+      .select('country')
+      .addSelect('COUNT(DISTINCT "ipAddress")', 'userCount')
+      .groupBy('country')
+      .getRawMany();
+  }
+}

--- a/backend/src/nft-marketplace-stub/entities/nft-item.entity.ts
+++ b/backend/src/nft-marketplace-stub/entities/nft-item.entity.ts
@@ -1,0 +1,8 @@
+export class NftItem {
+  id: string;
+  name: string;
+  imageUrl: string;
+  price: number;
+  description: string;
+  owner: string;
+}

--- a/backend/src/nft-marketplace-stub/nft-marketplace-stub.controller.spec.ts
+++ b/backend/src/nft-marketplace-stub/nft-marketplace-stub.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NftMarketplaceStubController } from './nft-marketplace-stub.controller';
+import { NftMarketplaceStubService } from './nft-marketplace-stub.service';
+
+describe('NftMarketplaceStubController', () => {
+  let controller: NftMarketplaceStubController;
+  let service: NftMarketplaceStubService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NftMarketplaceStubController],
+      providers: [NftMarketplaceStubService], // Use the real service since it's just a stub
+    }).compile();
+
+    controller = module.get<NftMarketplaceStubController>(
+      NftMarketplaceStubController,
+    );
+    service = module.get<NftMarketplaceStubService>(NftMarketplaceStubService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('listAllNfts', () => {
+    it('should call the findAll method on the service', () => {
+      const findAllSpy = jest.spyOn(service, 'findAll');
+      controller.listAllNfts();
+      expect(findAllSpy).toHaveBeenCalled();
+    });
+
+    it('should return an array of NFT items', () => {
+      const result = controller.listAllNfts();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toHaveProperty('id');
+      expect(result[0]).toHaveProperty('name');
+    });
+  });
+});

--- a/backend/src/nft-marketplace-stub/nft-marketplace-stub.controller.ts
+++ b/backend/src/nft-marketplace-stub/nft-marketplace-stub.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { NftMarketplaceStubService } from './nft-marketplace-stub.service';
+import { NftItem } from './entities/nft-item.entity';
+
+@Controller('nft-marketplace')
+export class NftMarketplaceStubController {
+  constructor(
+    private readonly marketplaceService: NftMarketplaceStubService,
+  ) {}
+
+  @Get('list')
+  listAllNfts(): NftItem[] {
+    return this.marketplaceService.findAll();
+  }
+}

--- a/backend/src/nft-marketplace-stub/nft-marketplace-stub.module.ts
+++ b/backend/src/nft-marketplace-stub/nft-marketplace-stub.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { NftMarketplaceStubService } from './nft-marketplace-stub.service';
+import { NftMarketplaceStubController } from './nft-marketplace-stub.controller';
+
+@Module({
+  controllers: [NftMarketplaceStubController],
+  providers: [NftMarketplaceStubService],
+})
+export class NftMarketplaceStubModule {}

--- a/backend/src/nft-marketplace-stub/nft-marketplace-stub.service.spec.ts
+++ b/backend/src/nft-marketplace-stub/nft-marketplace-stub.service.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NftMarketplaceStubService } from './nft-marketplace-stub.service';
+import { NftItem } from './entities/nft-item.entity';
+
+describe('NftMarketplaceStubService', () => {
+  let service: NftMarketplaceStubService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [NftMarketplaceStubService],
+    }).compile();
+
+    service = module.get<NftMarketplaceStubService>(NftMarketplaceStubService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should return a static array of NftItem objects', () => {
+      const nfts = service.findAll();
+
+      expect(Array.isArray(nfts)).toBe(true);
+      expect(nfts.length).toBe(4); 
+      const firstNft = nfts[0];
+      expect(firstNft).toBeInstanceOf(Object);
+      expect(firstNft).toHaveProperty('id');
+      expect(firstNft).toHaveProperty('name');
+      expect(firstNft).toHaveProperty('imageUrl');
+      expect(firstNft).toHaveProperty('price');
+      expect(firstNft).toHaveProperty('description');
+    });
+  });
+});

--- a/backend/src/nft-marketplace-stub/nft-marketplace-stub.service.ts
+++ b/backend/src/nft-marketplace-stub/nft-marketplace-stub.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { NftItem } from './entities/nft-item.entity';
+
+@Injectable()
+export class NftMarketplaceStubService {
+  private readonly mockNfts: NftItem[] = [
+    {
+      id: '1',
+      name: 'Cyber Lion',
+      imageUrl: 'https://example.com/images/cyber_lion.png',
+      price: 1.5,
+      description: 'A majestic lion from the digital savanna, roaring on the blockchain.',
+      owner: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B', // Vitalik Buterin's address
+    },
+    {
+      id: '2',
+      name: 'Pixel Explorer',
+      imageUrl: 'https://example.com/images/pixel_explorer.png',
+      price: 0.8,
+      description: 'A brave explorer venturing into the 8-bit unknown. Limited edition.',
+      owner: '0x1Db3439a222C519ab44bb1144fC28167b4Fa6EE6',
+    },
+    {
+      id: '3',
+      name: 'Astro Cat',
+      imageUrl: 'https://example.com/images/astro_cat.png',
+      price: 2.2,
+      description: 'This feline has seen things you wouldn’t believe among the stars.',
+      owner: '0x5095d437343461A4733122143B17978288019C34',
+    },
+     {
+      id: '4',
+      name: 'Glitch Mona Lisa',
+      imageUrl: 'https://example.com/images/glitch_mona.png',
+      price: 10.1,
+      description: 'A classic reborn in the digital age, beautifully broken.',
+      owner: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+    },
+  ];
+
+ 
+  findAll(): NftItem[] {
+    return this.mockNfts;
+  }
+}

--- a/backend/src/puzzle-access-log/dto/log-access.dto.ts
+++ b/backend/src/puzzle-access-log/dto/log-access.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class LogAccessDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  puzzleId: string;
+}

--- a/backend/src/puzzle-access-log/entities/puzzle-access-log.entity.ts
+++ b/backend/src/puzzle-access-log/entities/puzzle-access-log.entity.ts
@@ -1,0 +1,24 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('puzzle_access_logs')
+export class PuzzleAccessLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index() // Index for faster user-specific queries
+  @Column()
+  userId: string;
+
+  @Index() // Index for faster puzzle-specific queries
+  @Column()
+  puzzleId: string;
+
+  @CreateDateColumn()
+  accessTimestamp: Date;
+}

--- a/backend/src/puzzle-access-log/puzzle-access-log.controller.spec.ts
+++ b/backend/src/puzzle-access-log/puzzle-access-log.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PuzzleAccessLogController } from './puzzle-access-log.controller';
+import { PuzzleAccessLogService } from './puzzle-access-log.service';
+import { LogAccessDto } from './dto/log-access.dto';
+
+describe('PuzzleAccessLogController', () => {
+  let controller: PuzzleAccessLogController;
+  let service: PuzzleAccessLogService;
+
+  const mockAccessLogService = {
+    logAccess: jest.fn(),
+    getMostAccessedPuzzles: jest.fn(),
+    getUniqueUsersPerPuzzle: jest.fn(),
+    getTimeBasedTrends: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PuzzleAccessLogController],
+      providers: [{ provide: PuzzleAccessLogService, useValue: mockAccessLogService }],
+    }).compile();
+
+    controller = module.get<PuzzleAccessLogController>(PuzzleAccessLogController);
+    service = module.get<PuzzleAccessLogService>(PuzzleAccessLogService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should call logAccess service method on POST /log', () => {
+    const dto: LogAccessDto = { userId: 'u1', puzzleId: 'p1' };
+    controller.logAccess(dto);
+    expect(service.logAccess).toHaveBeenCalledWith(dto);
+  });
+
+  it('should call getMostAccessedPuzzles service method on GET /analytics/most-accessed', () => {
+    controller.getMostAccessedPuzzles();
+    expect(service.getMostAccessedPuzzles).toHaveBeenCalled();
+  });
+
+  it('should call getUniqueUsersPerPuzzle service method on GET /analytics/unique-users/:puzzleId', () => {
+    const puzzleId = 'p1';
+    controller.getUniqueUsersPerPuzzle(puzzleId);
+    expect(service.getUniqueUsersPerPuzzle).toHaveBeenCalledWith(puzzleId);
+  });
+
+  it('should call getTimeBasedTrends service method on GET /analytics/trends', () => {
+    controller.getTimeBasedTrends(14);
+    expect(service.getTimeBasedTrends).toHaveBeenCalledWith(14);
+  });
+});

--- a/backend/src/puzzle-access-log/puzzle-access-log.controller.ts
+++ b/backend/src/puzzle-access-log/puzzle-access-log.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Post, Body, Get, Param, Query, ParseIntPipe, DefaultValuePipe, ValidationPipe } from '@nestjs/common';
+import { PuzzleAccessLogService } from './puzzle-access-log.service';
+import { LogAccessDto } from './dto/log-access.dto';
+
+@Controller('puzzle-access')
+export class PuzzleAccessLogController {
+  constructor(private readonly accessLogService: PuzzleAccessLogService) {}
+
+  @Post('log')
+  logAccess(@Body(new ValidationPipe()) dto: LogAccessDto) {
+    return this.accessLogService.logAccess(dto);
+  }
+
+  @Get('analytics/most-accessed')
+  getMostAccessedPuzzles() {
+    return this.accessLogService.getMostAccessedPuzzles();
+  }
+
+  @Get('analytics/unique-users/:puzzleId')
+  getUniqueUsersPerPuzzle(@Param('puzzleId') puzzleId: string) {
+    return this.accessLogService.getUniqueUsersPerPuzzle(puzzleId);
+  }
+
+  @Get('analytics/trends')
+  getTimeBasedTrends(
+    @Query('days', new DefaultValuePipe(7), ParseIntPipe) days: number,
+  ) {
+    return this.accessLogService.getTimeBasedTrends(days);
+  }
+}

--- a/backend/src/puzzle-access-log/puzzle-access-log.module.ts
+++ b/backend/src/puzzle-access-log/puzzle-access-log.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PuzzleAccessLog } from './entities/puzzle-access-log.entity';
+import { PuzzleAccessLogService } from './puzzle-access-log.service';
+import { PuzzleAccessLogController } from './puzzle-access-log.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PuzzleAccessLog])],
+  providers: [PuzzleAccessLogService],
+  controllers: [PuzzleAccessLogController],
+})
+export class PuzzleAccessLogModule {}

--- a/backend/src/puzzle-access-log/puzzle-access-log.service.spec.ts
+++ b/backend/src/puzzle-access-log/puzzle-access-log.service.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PuzzleAccessLogService } from './puzzle-access-log.service';
+import { PuzzleAccessLog } from './entities/puzzle-access-log.entity';
+import { LogAccessDto } from './dto/log-access.dto';
+
+describe('PuzzleAccessLogService', () => {
+  let service: PuzzleAccessLogService;
+  let repo: Repository<PuzzleAccessLog>;
+
+  // Mock QueryBuilder for complex queries
+  const mockQueryBuilder = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn(),
+    getRawOne: jest.fn(),
+  };
+
+  const mockAccessLogRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    createQueryBuilder: jest.fn(() => mockQueryBuilder),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PuzzleAccessLogService,
+        { provide: getRepositoryToken(PuzzleAccessLog), useValue: mockAccessLogRepository },
+      ],
+    }).compile();
+
+    service = module.get<PuzzleAccessLogService>(PuzzleAccessLogService);
+    repo = module.get<Repository<PuzzleAccessLog>>(getRepositoryToken(PuzzleAccessLog));
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('logAccess should create and save a new log', async () => {
+    const dto: LogAccessDto = { userId: 'u1', puzzleId: 'p1' };
+    const newLog = new PuzzleAccessLog();
+    mockAccessLogRepository.create.mockReturnValue(newLog);
+    mockAccessLogRepository.save.mockResolvedValue(newLog);
+
+    await service.logAccess(dto);
+    expect(repo.create).toHaveBeenCalledWith(dto);
+    expect(repo.save).toHaveBeenCalledWith(newLog);
+  });
+
+  it('getMostAccessedPuzzles should return aggregated data', async () => {
+    const expectedData = [{ puzzleId: 'p1', accessCount: '10' }];
+    mockQueryBuilder.getRawMany.mockResolvedValue(expectedData);
+    
+    const result = await service.getMostAccessedPuzzles();
+    expect(repo.createQueryBuilder).toHaveBeenCalledWith('log');
+    expect(result).toEqual(expectedData);
+  });
+  
+  it('getUniqueUsersPerPuzzle should return a count of distinct users', async () => {
+    const puzzleId = 'p1';
+    const expectedCount = { count: '5' };
+    mockQueryBuilder.getRawOne.mockResolvedValue(expectedCount);
+
+    const result = await service.getUniqueUsersPerPuzzle(puzzleId);
+    expect(repo.createQueryBuilder().where).toHaveBeenCalledWith('log.puzzleId = :puzzleId', { puzzleId });
+    expect(result).toEqual({ uniqueUserCount: 5 });
+  });
+
+  it('getTimeBasedTrends should return time-series data', async () => {
+    const expectedData = [{ date: '2025-07-05', accessCount: '15' }];
+    mockQueryBuilder.getRawMany.mockResolvedValue(expectedData);
+
+    const result = await service.getTimeBasedTrends(7);
+    expect(repo.createQueryBuilder().where).toHaveBeenCalled();
+    expect(result).toEqual(expectedData);
+  });
+});

--- a/backend/src/puzzle-access-log/puzzle-access-log.service.ts
+++ b/backend/src/puzzle-access-log/puzzle-access-log.service.ts
@@ -1,0 +1,56 @@
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan, LessThan, Between } from 'typeorm';
+import { PuzzleAccessLog } from './entities/puzzle-access-log.entity';
+import { LogAccessDto } from './dto/log-access.dto';
+
+@Injectable()
+export class PuzzleAccessLogService {
+  constructor(
+    @InjectRepository(PuzzleAccessLog)
+    private readonly accessLogRepository: Repository<PuzzleAccessLog>,
+  ) {}
+
+  async logAccess(dto: LogAccessDto): Promise<PuzzleAccessLog> {
+    const newLog = this.accessLogRepository.create(dto);
+    return this.accessLogRepository.save(newLog);
+  }
+
+  
+
+  async getMostAccessedPuzzles(): Promise<{ puzzleId: string; accessCount: string }[]> {
+    return this.accessLogRepository
+      .createQueryBuilder('log')
+      .select('log.puzzleId', 'puzzleId')
+      .addSelect('COUNT(log.id)', 'accessCount')
+      .groupBy('log.puzzleId')
+      .orderBy('accessCount', 'DESC')
+      .limit(10) 
+      .getRawMany();
+  }
+
+  async getUniqueUsersPerPuzzle(puzzleId: string): Promise<{ uniqueUserCount: number }> {
+    const count = await this.accessLogRepository
+      .createQueryBuilder('log')
+      .select('COUNT(DISTINCT log.userId)', 'count')
+      .where('log.puzzleId = :puzzleId', { puzzleId })
+      .getRawOne();
+      
+    return { uniqueUserCount: parseInt(count.count, 10) || 0 };
+  }
+  
+  async getTimeBasedTrends(days: number = 7): Promise<{ date: string; accessCount: string }[]> {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - days);
+
+    return this.accessLogRepository
+      .createQueryBuilder('log')
+      .select("DATE(log.accessTimestamp)", "date")
+      .addSelect("COUNT(log.id)", "accessCount")
+      .where("log.accessTimestamp >= :startDate", { startDate })
+      .groupBy("DATE(log.accessTimestamp)")
+      .orderBy("date", "ASC")
+      .getRawMany();
+  }
+}

--- a/backend/src/puzzle-fork/dto/create-fork.dto.ts
+++ b/backend/src/puzzle-fork/dto/create-fork.dto.ts
@@ -1,0 +1,18 @@
+
+import { IsString, IsNotEmpty, IsInt, IsOptional } from 'class-validator';
+
+export class CreateForkDto {
+  @IsString()
+  @IsNotEmpty()
+  originalPuzzleId: string;
+
+  
+  @IsInt()
+  @IsOptional()
+  version?: number;
+
+  
+  @IsString()
+  @IsOptional()
+  newTitle?: string;
+}

--- a/backend/src/puzzle-fork/entities/forked-puzzle.entity.ts
+++ b/backend/src/puzzle-fork/entities/forked-puzzle.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('forked_puzzles')
+export class ForkedPuzzle {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // The ID of the original puzzle this was forked from
+  @Index()
+  @Column()
+  originalPuzzleId: string;
+
+  // The version number of the original puzzle at the time of forking
+  @Column()
+  forkedFromVersion: number;
+
+  @Column()
+  title: string;
+
+  // Store the full content of the puzzle at the time of the fork
+  @Column({ type: 'jsonb' })
+  content: Record<string, any>;
+
+  @CreateDateColumn()
+  forkedAt: Date;
+}

--- a/backend/src/puzzle-fork/puzzle-fork.controller.spec.ts
+++ b/backend/src/puzzle-fork/puzzle-fork.controller.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PuzzleForkController } from './puzzle-fork.controller';
+import { PuzzleForkService } from './puzzle-fork.service';
+import { CreateForkDto } from './dto/create-fork.dto';
+
+describe('PuzzleForkController', () => {
+  let controller: PuzzleForkController;
+  let service: PuzzleForkService;
+
+  const mockPuzzleForkService = {
+    fork: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PuzzleForkController],
+      providers: [{ provide: PuzzleForkService, useValue: mockPuzzleForkService }],
+    }).compile();
+
+    controller = module.get<PuzzleForkController>(PuzzleForkController);
+    service = module.get<PuzzleForkService>(PuzzleForkService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should call the fork service with the correct DTO', () => {
+    const dto: CreateForkDto = { originalPuzzleId: 'p1', version: 2 };
+    controller.forkPuzzle(dto);
+    expect(service.fork).toHaveBeenCalledWith(dto);
+  });
+});

--- a/backend/src/puzzle-fork/puzzle-fork.controller.ts
+++ b/backend/src/puzzle-fork/puzzle-fork.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, Body, UsePipes, ValidationPipe } from '@nestjs/common';
+import { PuzzleForkService } from './puzzle-fork.service';
+import { CreateForkDto } from './dto/create-fork.dto';
+
+@Controller('puzzles')
+export class PuzzleForkController {
+  constructor(private readonly puzzleForkService: PuzzleForkService) {}
+
+  /**
+   * Admin-only endpoint to fork a puzzle.
+   * In a real application, this should be protected with an AdminGuard.
+   * Ex: @UseGuards(AdminGuard)
+   */
+  @Post('fork')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  forkPuzzle(@Body() createForkDto: CreateForkDto) {
+    return this.puzzleForkService.fork(createForkDto);
+  }
+}

--- a/backend/src/puzzle-fork/puzzle-fork.module.ts
+++ b/backend/src/puzzle-fork/puzzle-fork.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PuzzleForkService } from './puzzle-fork.service';
+import { PuzzleForkController } from './puzzle-fork.controller';
+import { ForkedPuzzle } from './entities/forked-puzzle.entity';
+import { PuzzleVersion } from '../puzzle-versioning/entities/puzzle-version.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ForkedPuzzle, PuzzleVersion]),
+  ],
+  controllers: [PuzzleForkController],
+  providers: [PuzzleForkService],
+})
+export class PuzzleForkModule {}

--- a/backend/src/puzzle-fork/puzzle-fork.service.spec.ts
+++ b/backend/src/puzzle-fork/puzzle-fork.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { PuzzleForkService } from './puzzle-fork.service';
+import { ForkedPuzzle } from './entities/forked-puzzle.entity';
+import { PuzzleVersion } from '../puzzle-versioning/entities/puzzle-version.entity';
+
+describe('PuzzleForkService', () => {
+  let service: PuzzleForkService;
+  let forkedPuzzleRepo: Repository<ForkedPuzzle>;
+  let puzzleVersionRepo: Repository<PuzzleVersion>;
+
+  const mockForkedPuzzleRepo = { create: jest.fn(), save: jest.fn() };
+  const mockPuzzleVersionRepo = { findOne: jest.fn(), findOneBy: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PuzzleForkService,
+        { provide: getRepositoryToken(ForkedPuzzle), useValue: mockForkedPuzzleRepo },
+        { provide: getRepositoryToken(PuzzleVersion), useValue: mockPuzzleVersionRepo },
+      ],
+    }).compile();
+
+    service = module.get<PuzzleForkService>(PuzzleForkService);
+    forkedPuzzleRepo = module.get(getRepositoryToken(ForkedPuzzle));
+    puzzleVersionRepo = module.get(getRepositoryToken(PuzzleVersion));
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should fork the latest version of a puzzle', async () => {
+    const sourcePuzzle = { puzzleId: 'p1', version: 3, title: 'Original', content: {} };
+    mockPuzzleVersionRepo.findOne.mockResolvedValue(sourcePuzzle);
+    mockForkedPuzzleRepo.create.mockImplementation(p => p);
+    mockForkedPuzzleRepo.save.mockImplementation(p => Promise.resolve(p));
+
+    const result = await service.fork({ originalPuzzleId: 'p1' });
+
+    expect(puzzleVersionRepo.findOne).toHaveBeenCalledWith({ where: { puzzleId: 'p1' }, order: { version: 'DESC' } });
+    expect(forkedPuzzleRepo.create).toHaveBeenCalledWith(expect.objectContaining({ forkedFromVersion: 3 }));
+    expect(result.title).toBe('Fork of: Original');
+  });
+
+  it('should fork a specific version of a puzzle with a new title', async () => {
+    const sourcePuzzle = { puzzleId: 'p1', version: 1, title: 'Old Title', content: {} };
+    mockPuzzleVersionRepo.findOneBy.mockResolvedValue(sourcePuzzle);
+    mockForkedPuzzleRepo.create.mockImplementation(p => p);
+    mockForkedPuzzleRepo.save.mockImplementation(p => Promise.resolve(p));
+
+    const result = await service.fork({ originalPuzzleId: 'p1', version: 1, newTitle: 'My Fork' });
+
+    expect(puzzleVersionRepo.findOneBy).toHaveBeenCalledWith({ puzzleId: 'p1', version: 1 });
+    expect(forkedPuzzleRepo.create).toHaveBeenCalledWith(expect.objectContaining({ forkedFromVersion: 1 }));
+    expect(result.title).toBe('My Fork');
+  });
+
+  it('should throw NotFoundException if the source puzzle does not exist', async () => {
+    mockPuzzleVersionRepo.findOne.mockResolvedValue(null);
+    await expect(service.fork({ originalPuzzleId: 'p-non-existent' })).rejects.toThrow(NotFoundException);
+  });
+});

--- a/backend/src/puzzle-fork/puzzle-fork.service.ts
+++ b/backend/src/puzzle-fork/puzzle-fork.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ForkedPuzzle } from './entities/forked-puzzle.entity';
+
+import { PuzzleVersion } from '../puzzle-versioning/entities/puzzle-version.entity';
+import { CreateForkDto } from './dto/create-fork.dto';
+
+@Injectable()
+export class PuzzleForkService {
+  constructor(
+    @InjectRepository(ForkedPuzzle)
+    private readonly forkedPuzzleRepository: Repository<ForkedPuzzle>,
+    
+    @InjectRepository(PuzzleVersion)
+    private readonly puzzleVersionRepository: Repository<PuzzleVersion>,
+  ) {}
+
+  async fork(dto: CreateForkDto): Promise<ForkedPuzzle> {
+    const { originalPuzzleId, version, newTitle } = dto;
+
+    
+    const puzzleToFork = await this.findSourcePuzzle(originalPuzzleId, version);
+
+    if (!puzzleToFork) {
+      throw new NotFoundException(
+        `Puzzle with ID "${originalPuzzleId}" and version "${version || 'latest'}" not found.`,
+      );
+    }
+    
+    const newFork = this.forkedPuzzleRepository.create({
+      originalPuzzleId: puzzleToFork.puzzleId,
+      forkedFromVersion: puzzleToFork.version,
+      title: newTitle || `Fork of: ${puzzleToFork.title}`, 
+      content: puzzleToFork.content,
+    });
+
+    return this.forkedPuzzleRepository.save(newFork);
+  }
+
+
+  private async findSourcePuzzle(
+    puzzleId: string,
+    version?: number,
+  ): Promise<PuzzleVersion> {
+    if (version) {
+      return this.puzzleVersionRepository.findOneBy({ puzzleId, version });
+    }
+    
+    return this.puzzleVersionRepository.findOne({
+      where: { puzzleId },
+      order: { version: 'DESC' },
+    });
+  }
+}

--- a/backend/src/puzzle-versioning/dto/create-puzzle-version.dto.ts
+++ b/backend/src/puzzle-versioning/dto/create-puzzle-version.dto.ts
@@ -1,0 +1,16 @@
+
+import { IsString, IsNotEmpty, IsObject, IsOptional } from 'class-validator';
+
+export class CreatePuzzleVersionDto {
+  @IsString()
+  @IsOptional()
+  puzzleId?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsObject()
+  @IsNotEmpty()
+  content: Record<string, any>;
+}

--- a/backend/src/puzzle-versioning/entities/puzzle-version.entity.ts
+++ b/backend/src/puzzle-versioning/entities/puzzle-version.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('puzzle_versions')
+@Index(['puzzleId', 'version'], { unique: true })
+export class PuzzleVersion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  
+  @Column()
+  puzzleId: string;
+
+  @Column()
+  version: number;
+
+  @Column()
+  title: string;
+
+  
+  @Column({ type: 'jsonb' })
+  content: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/puzzle-versioning/puzzle-versioning.controller.spec.ts
+++ b/backend/src/puzzle-versioning/puzzle-versioning.controller.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PuzzleVersioningController } from './puzzle-versioning.controller';
+import { PuzzleVersioningService } from './puzzle-versioning.service';
+import { CreatePuzzleVersionDto } from './dto/create-puzzle-version.dto';
+
+describe('PuzzleVersioningController', () => {
+  let controller: PuzzleVersioningController;
+  let service: PuzzleVersioningService;
+
+  const mockPuzzleVersioningService = {
+    findLatestVersion: jest.fn(),
+    createNewVersion: jest.fn(),
+    findAllVersions: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PuzzleVersioningController],
+      providers: [
+        {
+          provide: PuzzleVersioningService,
+          useValue: mockPuzzleVersioningService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<PuzzleVersioningController>(PuzzleVersioningController);
+    service = module.get<PuzzleVersioningService>(PuzzleVersioningService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findLatestVersion', () => {
+    it('should call the service to find the latest version of a puzzle', async () => {
+      const puzzleId = 'puzzle-123';
+      await controller.findLatestVersion(puzzleId);
+      expect(service.findLatestVersion).toHaveBeenCalledWith(puzzleId);
+    });
+  });
+
+  describe('createNewVersion', () => {
+    it('should call the service to create a new puzzle version', async () => {
+      const dto: CreatePuzzleVersionDto = {
+        puzzleId: 'puzzle-123',
+        title: 'New Title',
+        content: { data: 'some content' },
+      };
+      await controller.createNewVersion(dto);
+      expect(service.createNewVersion).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe('findAllVersions', () => {
+    it('should call the service to find all versions of a puzzle', async () => {
+      const puzzleId = 'puzzle-123';
+      await controller.findAllVersions(puzzleId);
+      expect(service.findAllVersions).toHaveBeenCalledWith(puzzleId);
+    });
+  });
+});

--- a/backend/src/puzzle-versioning/puzzle-versioning.controller.ts
+++ b/backend/src/puzzle-versioning/puzzle-versioning.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Post, Body, Param, UsePipes, ValidationPipe } from '@nestjs/common';
+import { PuzzleVersioningService } from './puzzle-versioning.service';
+import { CreatePuzzleVersionDto } from './dto/create-puzzle-version.dto';
+
+@Controller('puzzles')
+export class PuzzleVersioningController {
+  constructor(private readonly puzzleVersioningService: PuzzleVersioningService) {}
+
+  
+  @Get(':puzzleId/latest')
+  findLatestVersion(@Param('puzzleId') puzzleId: string) {
+    return this.puzzleVersioningService.findLatestVersion(puzzleId);
+  }
+  
+  
+  @Post('versions')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  createNewVersion(@Body() createPuzzleVersionDto: CreatePuzzleVersionDto) {
+    return this.puzzleVersioningService.createNewVersion(createPuzzleVersionDto);
+  }
+  
+  @Get(':puzzleId/versions')
+  findAllVersions(@Param('puzzleId') puzzleId: string) {
+    return this.puzzleVersioningService.findAllVersions(puzzleId);
+  }
+}

--- a/backend/src/puzzle-versioning/puzzle-versioning.module.ts
+++ b/backend/src/puzzle-versioning/puzzle-versioning.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PuzzleVersion } from './entities/puzzle-version.entity';
+import { PuzzleVersioningService } from './puzzle-versioning.service';
+import { PuzzleVersioningController } from './puzzle-versioning.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PuzzleVersion])],
+  providers: [PuzzleVersioningService],
+  controllers: [PuzzleVersioningController],
+})
+export class PuzzleVersioningModule {}

--- a/backend/src/puzzle-versioning/puzzle-versioning.service.spec.ts
+++ b/backend/src/puzzle-versioning/puzzle-versioning.service.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { PuzzleVersioningService } from './puzzle-versioning.service';
+import { PuzzleVersion } from './entities/puzzle-version.entity';
+import { CreatePuzzleVersionDto } from './dto/create-puzzle-version.dto';
+
+describe('PuzzleVersioningService', () => {
+  let service: PuzzleVersioningService;
+  let repo: Repository<PuzzleVersion>;
+
+  const mockPuzzleVersionRepository = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PuzzleVersioningService,
+        {
+          provide: getRepositoryToken(PuzzleVersion),
+          useValue: mockPuzzleVersionRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PuzzleVersioningService>(PuzzleVersioningService);
+    repo = module.get<Repository<PuzzleVersion>>(getRepositoryToken(PuzzleVersion));
+    // Reset mocks before each test
+    jest.clearAllMocks(); 
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createNewVersion', () => {
+    it('should create version 1 for a new puzzle', async () => {
+      const dto: CreatePuzzleVersionDto = { title: 'First Puzzle', content: {} };
+      
+      // Since it's a new puzzle, findOne returns null for the latest version
+      mockPuzzleVersionRepository.findOne.mockResolvedValue(null);
+      mockPuzzleVersionRepository.create.mockImplementation(p => p);
+      mockPuzzleVersionRepository.save.mockImplementation(p => Promise.resolve({ ...p, id: 'uuid' }));
+
+      // We spy on the service itself to check the call to findLatestVersion
+      const findLatestSpy = jest.spyOn(service, 'findLatestVersion').mockImplementation(() => {
+        throw new NotFoundException();
+      });
+
+      const result = await service.createNewVersion(dto);
+
+      expect(result.version).toBe(1);
+      expect(result.puzzleId).toBeDefined();
+      expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ version: 1 }));
+      findLatestSpy.mockRestore();
+    });
+
+    it('should increment the version for an existing puzzle', async () => {
+      const puzzleId = 'puzzle-123';
+      const dto: CreatePuzzleVersionDto = { puzzleId, title: 'Updated Puzzle', content: {} };
+      const latestVersion = { puzzleId, version: 3, title: 'Old Title', content: {} };
+
+      const findLatestSpy = jest.spyOn(service, 'findLatestVersion').mockResolvedValue(latestVersion as PuzzleVersion);
+      mockPuzzleVersionRepository.create.mockImplementation(p => p);
+      mockPuzzleVersionRepository.save.mockImplementation(p => Promise.resolve({ ...p, id: 'uuid' }));
+      
+      const result = await service.createNewVersion(dto);
+
+      expect(result.version).toBe(4);
+      expect(result.puzzleId).toBe(puzzleId);
+      expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ version: 4 }));
+      findLatestSpy.mockRestore();
+    });
+  });
+
+  describe('findLatestVersion', () => {
+    it('should return the latest version', async () => {
+      const puzzleId = 'puzzle-123';
+      const mockVersion = { puzzleId, version: 1 };
+      mockPuzzleVersionRepository.findOne.mockResolvedValue(mockVersion);
+
+      const result = await service.findLatestVersion(puzzleId);
+
+      expect(repo.findOne).toHaveBeenCalledWith({ where: { puzzleId }, order: { version: 'DESC' } });
+      expect(result).toEqual(mockVersion);
+    });
+
+    it('should throw NotFoundException if no puzzle is found', async () => {
+      mockPuzzleVersionRepository.findOne.mockResolvedValue(null);
+      await expect(service.findLatestVersion('non-existent-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findAllVersions', () => {
+    it('should return all versions for a puzzle', async () => {
+      const puzzleId = 'puzzle-123';
+      const mockVersions = [{ puzzleId, version: 2 }, { puzzleId, version: 1 }];
+      mockPuzzleVersionRepository.find.mockResolvedValue(mockVersions);
+
+      const result = await service.findAllVersions(puzzleId);
+      expect(repo.find).toHaveBeenCalledWith({ where: { puzzleId }, order: { version: 'DESC' } });
+      expect(result).toEqual(mockVersions);
+    });
+
+    it('should throw NotFoundException if no versions are found', async () => {
+      mockPuzzleVersionRepository.find.mockResolvedValue([]);
+      await expect(service.findAllVersions('non-existent-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/puzzle-versioning/puzzle-versioning.service.ts
+++ b/backend/src/puzzle-versioning/puzzle-versioning.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PuzzleVersion } from './entities/puzzle-version.entity';
+import { CreatePuzzleVersionDto } from './dto/create-puzzle-version.dto';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class PuzzleVersioningService {
+  constructor(
+    @InjectRepository(PuzzleVersion)
+    private readonly puzzleVersionRepository: Repository<PuzzleVersion>,
+  ) {}
+
+  async createNewVersion(dto: CreatePuzzleVersionDto): Promise<PuzzleVersion> {
+    let version = 1;
+    const puzzleId = dto.puzzleId || uuidv4(); 
+
+    if (dto.puzzleId) {
+      const latestVersion = await this.findLatestVersion(dto.puzzleId);
+      if (latestVersion) {
+        version = latestVersion.version + 1;
+      }
+    }
+
+    const newPuzzleVersion = this.puzzleVersionRepository.create({
+      ...dto,
+      puzzleId,
+      version,
+    });
+
+    return this.puzzleVersionRepository.save(newPuzzleVersion);
+  }
+
+  async findLatestVersion(puzzleId: string): Promise<PuzzleVersion> {
+    const latest = await this.puzzleVersionRepository.findOne({
+      where: { puzzleId },
+      order: { version: 'DESC' },
+    });
+
+    if (!latest) {
+      throw new NotFoundException(`No puzzle found with ID "${puzzleId}"`);
+    }
+    return latest;
+  }
+
+  async findAllVersions(puzzleId: string): Promise<PuzzleVersion[]> {
+    const versions = await this.puzzleVersionRepository.find({
+      where: { puzzleId },
+      order: { version: 'DESC' }, 
+    });
+
+    if (!versions || versions.length === 0) {
+        throw new NotFoundException(`No puzzle found with ID "${puzzleId}"`);
+    }
+    return versions;
+  }
+}


### PR DESCRIPTION
PuzzleForkModule
Summary
Added PuzzleForkModule to support forking existing puzzles into alternate versions while preserving version lineage.

Features
ForkedPuzzle entity tracks forked puzzles
Maintains relationship between original and forked versions
Admins can fork puzzles via admin interface

closes #496 